### PR TITLE
Fix rejected verification status indicators

### DIFF
--- a/dodepus-casino/src/pages/Admin/verification/components/VerificationFieldBadges.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/components/VerificationFieldBadges.jsx
@@ -1,11 +1,11 @@
 import { Badge, Button } from 'react-bootstrap';
-import { Circle, CircleAlert, CircleHelp, CheckCircle2 } from 'lucide-react';
+import { Circle, CircleHelp, CheckCircle2, CircleX } from 'lucide-react';
 import { VERIFICATION_MODULES } from '../../../../shared/verification/index.js';
 
 const ICON_CONFIG = {
   approved: { Component: CheckCircle2, className: 'text-success' },
   in_review: { Component: CircleHelp, className: 'text-warning' },
-  rejected: { Component: CircleAlert, style: { color: '#fd7e14' } },
+  rejected: { Component: CircleX, className: 'text-danger' },
   waiting: { Component: Circle, className: 'text-secondary' },
 };
 

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationStatusBlock/VerificationStatusBlock.jsx
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationStatusBlock/VerificationStatusBlock.jsx
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { Row, Col, Card, Button, Toast, ToastContainer, Alert } from 'react-bootstrap';
-import { Circle, CheckCircle, CircleHelp, CircleAlert } from 'lucide-react';
+import { Circle, CheckCircle, CircleHelp, CircleX } from 'lucide-react';
 import { useNavigate } from 'react-router-dom';
 import { useAuth } from '../../../../../app/AuthContext.jsx';
 import {
@@ -25,7 +25,7 @@ const ICON_BG_CLASS = Object.freeze({
 const ICON_COMPONENT = Object.freeze({
   waiting: (size) => <Circle size={size} className="text-primary" />,
   in_review: (size) => <CircleHelp size={size} className="text-warning" />,
-  rejected: (size) => <CircleAlert size={size} className="text-danger" />,
+  rejected: (size) => <CircleX size={size} className="text-danger" />,
   approved: (size) => <CheckCircle size={size} className="text-success" />,
 });
 


### PR DESCRIPTION
## Summary
- replace the rejected module icon with a red cross in the admin verification badges
- update the profile verification status cards to use the same red cross icon for rejected modules

## Testing
- npm run lint *(fails due to pre-existing lint errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68e589ba8688832fa159b7c11eb83ecd