### PR TITLE
Add client and admin verification flows backed by local simulation

### DIFF
--- a/dodepus-casino/local-sim/admin/logs/index.js
+++ b/dodepus-casino/local-sim/admin/logs/index.js
@@ -7,6 +7,7 @@ import { PROMO_ARCHIVE_LOGS } from './promoArchive.js';
 import { ROLE_EDIT_LOGS } from './roleEdit.js';
 import { ROLES_LOGS } from './roles.js';
 import { STAFF_CHAT_LOGS } from './staffChat.js';
+import { VERIFICATION_LOGS } from './verification.js';
 import {
   TRANSACTIONS_LOG_STORAGE_KEY,
   TRANSACTIONS_STATIC_LOGS,
@@ -22,6 +23,7 @@ const ADMIN_LOG_SECTIONS = Object.freeze([
   { value: 'promocode-archive', label: 'Архив Promo' },
   { value: 'roles', label: 'Выдать роль' },
   { value: 'role-edit', label: 'Изменить роль' },
+  { value: 'verification', label: 'Верификация' },
   { value: 'transactions', label: 'Транзакции' },
   { value: 'moderators-chat', label: 'Модератор Чат' },
   { value: 'administrators-chat', label: 'Админ Чат' },
@@ -59,6 +61,7 @@ const STATIC_SECTION_LOGS = Object.freeze([
   ...PROMO_ARCHIVE_LOGS,
   ...ROLES_LOGS,
   ...ROLE_EDIT_LOGS,
+  ...VERIFICATION_LOGS,
   ...MODERATORS_CHAT_LOGS,
   ...ADMINISTRATORS_CHAT_LOGS,
   ...STAFF_CHAT_LOGS,

--- a/dodepus-casino/local-sim/admin/logs/verification.js
+++ b/dodepus-casino/local-sim/admin/logs/verification.js
@@ -1,0 +1,11 @@
+export const VERIFICATION_LOGS = Object.freeze([
+  {
+    id: 'LOG-2024-0007',
+    adminId: 'ADM-005',
+    adminName: 'Анна Фролова',
+    role: 'operator',
+    section: 'verification',
+    action: 'Подтвердила документы клиента #5077',
+    createdAt: '2024-04-15T11:54:00.000Z',
+  },
+]);

--- a/dodepus-casino/local-sim/admin/verification.js
+++ b/dodepus-casino/local-sim/admin/verification.js
@@ -1,0 +1,821 @@
+import { readAdminClients } from './clients';
+import { loadExtras, saveExtras } from '../auth/profileExtras';
+import { appendAdminLog } from './logs/index.js';
+
+export const ADMIN_VERIFICATION_EVENT = 'dodepus:admin-verification-change';
+
+const VALID_STATUSES = Object.freeze(['idle', 'pending', 'rejected', 'approved']);
+
+const normalizeString = (value, fallback = '') => {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+};
+
+const normalizeStatus = (value) => {
+  const normalized = normalizeString(value).toLowerCase();
+  if (!normalized) return 'pending';
+  if (normalized === 'approved' || normalized === 'verified' || normalized === 'done') {
+    return 'approved';
+  }
+  if (normalized === 'rejected' || normalized === 'declined' || normalized === 'denied') {
+    return 'rejected';
+  }
+  if (['in_review', 'inreview', 'pending', 'processing'].includes(normalized)) {
+    return 'pending';
+  }
+  if (normalized === 'waiting' || normalized === 'idle' || normalized === 'new' || normalized === 'requested') {
+    return 'idle';
+  }
+  if (normalized === 'partial') {
+    return 'pending';
+  }
+  if (normalized === 'reset') {
+    return 'idle';
+  }
+  if (VALID_STATUSES.includes(normalized)) {
+    return normalized;
+  }
+  return 'pending';
+};
+
+const normalizeFields = (fields = {}) => ({
+  email: Boolean(fields?.email),
+  phone: Boolean(fields?.phone),
+  address: Boolean(fields?.address),
+  doc: Boolean(fields?.doc),
+});
+
+const normalizeFieldsPatch = (fields = {}) => {
+  if (!fields || typeof fields !== 'object') {
+    return {};
+  }
+
+  const patch = {};
+
+  if ('email' in fields) {
+    patch.email = Boolean(fields.email);
+  }
+
+  if ('phone' in fields) {
+    patch.phone = Boolean(fields.phone);
+  }
+
+  if ('address' in fields) {
+    patch.address = Boolean(fields.address);
+  }
+
+  if ('doc' in fields) {
+    patch.doc = Boolean(fields.doc);
+  }
+
+  if ('document' in fields) {
+    patch.doc = Boolean(fields.document);
+  }
+
+  return patch;
+};
+
+const mergeFieldStates = (current = {}, patch = {}) => {
+  const normalizedCurrent = normalizeFields(current);
+  const normalizedPatch = normalizeFieldsPatch(patch);
+  const keys = new Set([
+    ...Object.keys(normalizedCurrent),
+    ...Object.keys(normalizedPatch),
+  ]);
+
+  const result = {};
+  keys.forEach((key) => {
+    if (!key) return;
+    result[key] = normalizedPatch[key] ?? normalizedCurrent[key] ?? false;
+  });
+
+  return normalizeFields(result);
+};
+
+const normalizeNotes = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : '';
+};
+
+const GENDER_MALE_VALUES = Object.freeze([
+  'male',
+  'm',
+  'man',
+  'м',
+  'м.',
+  'муж',
+  'муж.',
+  'мужчина',
+  'мужской',
+]);
+
+const GENDER_FEMALE_VALUES = Object.freeze([
+  'female',
+  'f',
+  'woman',
+  'ж',
+  'ж.',
+  'жен',
+  'жен.',
+  'женщина',
+  'женский',
+]);
+
+const GENDER_CLEAR_VALUES = Object.freeze([
+  '',
+  'unspecified',
+  'не указан',
+  'не указано',
+  'не выбрано',
+  'не выбран',
+  'не выбрана',
+  'unknown',
+  'другое',
+  'other',
+]);
+
+const normalizeGenderValue = (value) => {
+  const normalized = normalizeString(value).toLowerCase();
+  if (!normalized) {
+    return '';
+  }
+
+  if (GENDER_MALE_VALUES.includes(normalized)) {
+    return 'male';
+  }
+
+  if (GENDER_FEMALE_VALUES.includes(normalized)) {
+    return 'female';
+  }
+
+  if (GENDER_CLEAR_VALUES.includes(normalized)) {
+    return '';
+  }
+
+  return '';
+};
+
+const normalizeProfilePatch = (patch = {}) => {
+  if (!patch || typeof patch !== 'object') {
+    return {};
+  }
+
+  const normalized = {};
+
+  if ('address' in patch) {
+    normalized.address = normalizeString(patch.address);
+  }
+
+  if ('city' in patch) {
+    normalized.city = normalizeString(patch.city);
+  }
+
+  if ('country' in patch) {
+    normalized.country = normalizeString(patch.country);
+  }
+
+  if ('firstName' in patch) {
+    normalized.firstName = normalizeString(patch.firstName);
+  }
+
+  if ('lastName' in patch) {
+    normalized.lastName = normalizeString(patch.lastName);
+  }
+
+  if ('dob' in patch) {
+    const normalizedDob = normalizeString(patch.dob);
+    normalized.dob = normalizedDob || null;
+  }
+
+  if ('gender' in patch) {
+    const normalizedInput = normalizeString(patch.gender);
+    const normalizedGender = normalizeGenderValue(normalizedInput);
+
+    if (normalizedGender) {
+      normalized.gender = normalizedGender;
+    } else if (!normalizedInput || GENDER_CLEAR_VALUES.includes(normalizedInput.toLowerCase())) {
+      normalized.gender = '';
+    }
+  }
+
+  return normalized;
+};
+
+const clamp = (value, min, max) => Math.min(max, Math.max(min, value));
+
+const parseTimestamp = (value) => {
+  if (!value) return null;
+  try {
+    const time = Date.parse(value);
+    if (!Number.isFinite(time)) return null;
+    return time;
+  } catch {
+    return null;
+  }
+};
+
+const clone = (value) => {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+};
+
+const buildProfileSnapshot = (client, extras) => {
+  const source = extras && typeof extras === 'object' ? extras : client?.profile;
+
+  return {
+    email: normalizeString(client?.email),
+    phone: normalizeString(client?.phone),
+    address: normalizeString(source?.address),
+    city: normalizeString(source?.city),
+    country: normalizeString(source?.country),
+    firstName: normalizeString(source?.firstName),
+    lastName: normalizeString(source?.lastName),
+    dob: normalizeString(source?.dob),
+    gender: normalizeGenderValue(source?.gender ?? source?.sex ?? ''),
+  };
+};
+
+const createHistoryEntry = ({
+  request,
+  reviewer,
+  status,
+  notes,
+  completedFields,
+  requestedFields,
+  clearedFields,
+}) => {
+  const timestamp = new Date().toISOString();
+  return {
+    id: `vrh_${Date.now().toString(36)}${Math.random().toString(36).slice(2, 6)}`,
+    requestId: normalizeString(request?.id),
+    status: normalizeStatus(status),
+    reviewer: {
+      id: normalizeString(reviewer?.id),
+      name: normalizeString(reviewer?.name),
+      role: normalizeString(reviewer?.role),
+    },
+    notes: normalizeNotes(notes),
+    updatedAt: timestamp,
+    completedFields: normalizeFields(completedFields),
+    requestedFields: normalizeFields(requestedFields ?? completedFields),
+    clearedFields: normalizeFields(clearedFields),
+  };
+};
+
+const sanitizeHistoryEntries = (history, fallbackRequest) => {
+  if (!Array.isArray(history)) {
+    return [];
+  }
+
+  return history
+    .map((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return null;
+      }
+
+      const status = normalizeStatus(entry.status ?? fallbackRequest?.status);
+      const normalizedCompleted = normalizeFields(
+        entry.completedFields ?? fallbackRequest?.completedFields,
+      );
+      const normalizedRequested = normalizeFields(
+        entry.requestedFields ?? entry.completedFields ?? fallbackRequest?.requestedFields,
+      );
+
+      const updatedAt = normalizeString(entry.updatedAt) || fallbackRequest?.updatedAt;
+
+      return {
+        id: normalizeString(entry.id) || `vrh_${Math.random().toString(36).slice(2, 8)}`,
+        requestId: normalizeString(entry.requestId ?? fallbackRequest?.id),
+        status,
+        reviewer: {
+          id: normalizeString(entry.reviewer?.id),
+          name: normalizeString(entry.reviewer?.name),
+          role: normalizeString(entry.reviewer?.role),
+        },
+        notes: normalizeNotes(entry.notes),
+        updatedAt: updatedAt || new Date().toISOString(),
+        completedFields: normalizedCompleted,
+        requestedFields: normalizedRequested,
+        clearedFields: normalizeFields(entry.clearedFields),
+      };
+    })
+    .filter(Boolean);
+};
+
+const getEventTarget = () => {
+  if (typeof window !== 'undefined') return window;
+  if (typeof globalThis !== 'undefined' && globalThis?.addEventListener) {
+    return globalThis;
+  }
+  return null;
+};
+
+const emitVerificationChange = (detail) => {
+  const target = getEventTarget();
+  if (!target?.dispatchEvent || typeof CustomEvent !== 'function') return;
+
+  try {
+    target.dispatchEvent(new CustomEvent(ADMIN_VERIFICATION_EVENT, { detail: detail ?? null }));
+  } catch (error) {
+    console.warn('Failed to emit admin verification change event', error);
+  }
+};
+
+export const notifyAdminVerificationRequestsChanged = (detail) => emitVerificationChange(detail);
+
+const buildRequestEntry = (client, request) => {
+  if (!client || !request || typeof request !== 'object') return null;
+
+  const id = normalizeString(request.id);
+  if (!id) return null;
+
+  const completedFields = normalizeFields(request.completedFields);
+  const requestedFields = normalizeFields(request.requestedFields ?? request.completedFields);
+  const requestedCount = Object.values(requestedFields).filter(Boolean).length;
+  const calculatedCompleted = Object.values(completedFields).filter(Boolean).length;
+  const baseTotal = Math.max(requestedCount, calculatedCompleted);
+  const totalFields = clamp(baseTotal || Object.keys(requestedFields).length || 4, 1, 10);
+  const completedCount = clamp(calculatedCompleted, 0, totalFields);
+
+  const submittedAt = normalizeString(
+    request.submittedAt || request.createdAt || request.updatedAt || '',
+    '',
+  );
+  const updatedAt = normalizeString(request.updatedAt || submittedAt, submittedAt);
+  const reviewedAt = normalizeString(request.reviewedAt || updatedAt, updatedAt);
+
+  const attachments = Array.isArray(client?.profile?.verificationUploads)
+    ? client.profile.verificationUploads.map((upload) => clone(upload))
+    : [];
+
+  const profile = buildProfileSnapshot(client, client?.profile);
+  const history = sanitizeHistoryEntries(request.history, request);
+
+  return {
+    id,
+    requestId: id,
+    userId: normalizeString(client.id, 'UNKNOWN'),
+    userEmail: normalizeString(client.email),
+    userPhone: normalizeString(client.phone),
+    userNickname: normalizeString(client?.profile?.nickname),
+    status: normalizeStatus(request.status),
+    submittedAt,
+    updatedAt,
+    reviewedAt,
+    completedFields: { ...completedFields },
+    requestedFields: { ...requestedFields },
+    completedCount,
+    totalFields,
+    attachments,
+    profile,
+    history,
+    reviewer: {
+      id: normalizeString(request.reviewerId),
+      name: normalizeString(request.reviewerName),
+      role: normalizeString(request.reviewerRole),
+    },
+    notes: normalizeNotes(request.notes),
+    metadata: request.metadata && typeof request.metadata === 'object' ? clone(request.metadata) : undefined,
+    sortTimestamp: parseTimestamp(updatedAt) ?? parseTimestamp(submittedAt) ?? 0,
+  };
+};
+
+export const readAdminVerificationRequests = () => {
+  const clients = readAdminClients();
+  const entries = [];
+
+  clients.forEach((client) => {
+    const requests = Array.isArray(client?.profile?.verificationRequests)
+      ? client.profile.verificationRequests
+      : [];
+
+    requests.forEach((request) => {
+      const entry = buildRequestEntry(client, request);
+      if (entry) {
+        entries.push(entry);
+      }
+    });
+  });
+
+  entries.sort((a, b) => (b.sortTimestamp || 0) - (a.sortTimestamp || 0));
+  return entries;
+};
+
+const createAbortError = (reason) => {
+  if (reason instanceof Error) return reason;
+  if (typeof DOMException === 'function') {
+    return new DOMException('Aborted', 'AbortError');
+  }
+  const error = new Error('Aborted');
+  error.name = 'AbortError';
+  return error;
+};
+
+export function listAdminVerificationRequests({ signal, delay = 200 } = {}) {
+  if (signal?.aborted) {
+    return Promise.reject(createAbortError(signal.reason));
+  }
+
+  return new Promise((resolve, reject) => {
+    const timeout = Math.max(0, delay);
+
+    const complete = () => {
+      try {
+        const requests = readAdminVerificationRequests().map((entry) => ({ ...entry }));
+        resolve(requests);
+      } catch (error) {
+        reject(error);
+      }
+    };
+
+    if (!timeout) {
+      complete();
+      return;
+    }
+
+    const timer = setTimeout(complete, timeout);
+
+    if (signal) {
+      signal.addEventListener(
+        'abort',
+        () => {
+          clearTimeout(timer);
+          reject(createAbortError(signal.reason));
+        },
+        { once: true },
+      );
+    }
+  });
+}
+
+export const subscribeToAdminVerificationRequests = (callback) => {
+  const target = getEventTarget();
+  if (!target?.addEventListener || typeof callback !== 'function') {
+    return () => {};
+  }
+
+  const handler = (event) => {
+    try {
+      callback(event?.detail ?? null);
+    } catch (error) {
+      console.warn('Failed to handle admin verification subscription callback', error);
+    }
+  };
+
+  target.addEventListener(ADMIN_VERIFICATION_EVENT, handler);
+  return () => {
+    target.removeEventListener(ADMIN_VERIFICATION_EVENT, handler);
+  };
+};
+
+const findRequestOwner = (requestId) => {
+  if (!requestId) return null;
+  const clients = readAdminClients();
+  return (
+    clients.find((client) =>
+      Array.isArray(client?.profile?.verificationRequests) &&
+      client.profile.verificationRequests.some((request) => request?.id === requestId),
+    ) || null
+  );
+};
+
+const buildReviewerInfo = (reviewer = {}) => {
+  const id =
+    normalizeString(reviewer.id) ||
+    normalizeString(reviewer.adminId) ||
+    normalizeString(reviewer.userId);
+
+  const name =
+    normalizeString(reviewer.name) ||
+    normalizeString(reviewer.adminName) ||
+    normalizeString(reviewer.fullName);
+
+  const role =
+    normalizeString(reviewer.role) ||
+    normalizeString(reviewer.adminRole) ||
+    normalizeString(reviewer.position);
+
+  return { id, name, role };
+};
+
+const ensureValidStatus = (status) => {
+  const normalized = normalizeStatus(status);
+  if (!VALID_STATUSES.includes(normalized)) {
+    throw new Error('Некорректный статус верификации');
+  }
+  return normalized;
+};
+
+export const updateVerificationRequestStatus = ({
+  requestId,
+  status,
+  reviewer,
+  notes,
+  completedFields,
+  requestedFields,
+  profilePatch,
+} = {}) => {
+  const normalizedStatus = ensureValidStatus(status);
+  const owner = findRequestOwner(requestId);
+  if (!owner) {
+    throw new Error('Запрос верификации не найден');
+  }
+
+  const extras = loadExtras(owner.id);
+  const requests = Array.isArray(extras.verificationRequests)
+    ? extras.verificationRequests.slice()
+    : [];
+  const index = requests.findIndex((request) => request?.id === requestId);
+  if (index < 0) {
+    throw new Error('Не удалось обновить запрос верификации');
+  }
+
+  const reviewerInfo = buildReviewerInfo(reviewer);
+  const nowIso = new Date().toISOString();
+
+  const previous = requests[index] || {};
+  const normalizedCompleted = normalizeFields(previous.completedFields);
+  const normalizedRequested = normalizeFields(previous.requestedFields ?? previous.completedFields);
+
+  const mergedCompleted = mergeFieldStates(normalizedCompleted, completedFields);
+  const mergedRequested = mergeFieldStates(normalizedRequested, requestedFields);
+
+  const nextCompleted = mergedCompleted;
+  const nextRequested = mergeFieldStates(mergedRequested, mergedCompleted);
+
+  const completedTrueCount = Object.values(nextCompleted).filter(Boolean).length;
+  const requestedTrueCount = Object.values(nextRequested).filter(Boolean).length;
+  const relevantTotal = Math.max(
+    requestedTrueCount,
+    completedTrueCount,
+    Object.keys(nextCompleted).length,
+    Object.keys(nextRequested).length,
+  );
+
+  const totalFields = clamp(relevantTotal || Object.keys(nextRequested).length || 4, 1, 10);
+  const completedCount = clamp(completedTrueCount, 0, totalFields);
+  const hasOutstanding = requestedTrueCount > completedTrueCount;
+  const finalStatus =
+    normalizedStatus === 'rejected'
+      ? 'rejected'
+      : hasOutstanding
+        ? 'pending'
+        : 'approved';
+
+  const normalizedNotes = normalizeNotes(notes);
+  const previousHistory = sanitizeHistoryEntries(previous.history, previous);
+  const historyEntry = createHistoryEntry({
+    request: previous,
+    reviewer: reviewerInfo,
+    status: finalStatus,
+    notes: normalizedNotes,
+    completedFields: nextCompleted,
+    requestedFields: nextRequested,
+    clearedFields: previous.clearedFields,
+  });
+
+  const nextHistory = [historyEntry, ...previousHistory];
+
+  const updatedRequest = {
+    ...previous,
+    status: finalStatus,
+    reviewerId: reviewerInfo.id,
+    reviewerName: reviewerInfo.name,
+    reviewerRole: reviewerInfo.role,
+    reviewedAt: nowIso,
+    updatedAt: nowIso,
+    completedFields: nextCompleted,
+    requestedFields: nextRequested,
+    completedCount,
+    totalFields,
+    notes: normalizedNotes,
+    history: nextHistory,
+  };
+
+  const nextRequests = requests.slice();
+  nextRequests[index] = updatedRequest;
+
+  const normalizedProfilePatch = normalizeProfilePatch(profilePatch);
+
+  const nextExtras = {
+    ...extras,
+    ...normalizedProfilePatch,
+    verificationRequests: nextRequests,
+  };
+
+  saveExtras(owner.id, nextExtras);
+
+  try {
+    notifyAdminVerificationRequestsChanged({
+      type: 'updated',
+      requestId,
+      userId: owner.id,
+      status: finalStatus,
+    });
+  } catch (error) {
+    console.warn('Failed to broadcast admin verification status change', error);
+  }
+
+  try {
+    const contextStatus =
+      finalStatus === 'approved' ? 'approved' : finalStatus === 'rejected' ? 'rejected' : 'pending';
+    const actionLabel = (() => {
+      switch (contextStatus) {
+        case 'approved':
+          return `Подтвердил запрос верификации #${requestId}`;
+        case 'rejected':
+          return `Отклонил запрос верификации #${requestId}`;
+        default:
+          return `Обновил запрос верификации #${requestId}`;
+      }
+    })();
+
+    appendAdminLog({
+      section: 'verification',
+      action: actionLabel,
+      adminId: reviewerInfo.id,
+      adminName: reviewerInfo.name,
+      role: reviewerInfo.role,
+      context: `verification:${contextStatus}:${requestId}`,
+      metadata: {
+        requestId,
+        userId: owner.id,
+        status: finalStatus,
+        completedFields: nextCompleted,
+        requestedFields: nextRequested,
+      },
+    });
+  } catch (error) {
+    console.warn('Не удалось записать лог действия верификации', error);
+  }
+
+  const clientForEntry = {
+    ...owner,
+    profile: {
+      ...owner.profile,
+      ...nextExtras,
+      verificationRequests: nextRequests,
+    },
+  };
+
+  return buildRequestEntry(clientForEntry, updatedRequest);
+};
+
+const buildClearedSelection = (modules = {}) => {
+  const normalized = normalizeFields(modules);
+  const result = {};
+  Object.keys(normalized).forEach((key) => {
+    if (!normalized[key]) {
+      return;
+    }
+    result[key] = true;
+  });
+  return normalizeFields(result);
+};
+
+export const resetVerificationRequestModules = ({
+  requestId,
+  modules,
+  reviewer,
+  notes,
+} = {}) => {
+  const clearedMap = buildClearedSelection(modules);
+  const clearedKeys = Object.keys(clearedMap).filter((key) => clearedMap[key]);
+
+  if (!clearedKeys.length) {
+    throw new Error('Выберите хотя бы один модуль для сброса');
+  }
+
+  const owner = findRequestOwner(requestId);
+  if (!owner) {
+    throw new Error('Запрос верификации не найден');
+  }
+
+  const extras = loadExtras(owner.id);
+  const requests = Array.isArray(extras?.verificationRequests)
+    ? extras.verificationRequests.slice()
+    : [];
+
+  const index = requests.findIndex((entry) => entry?.id === requestId);
+  if (index === -1) {
+    throw new Error('Запрос верификации не найден');
+  }
+
+  const previous = requests[index];
+  const reviewerInfo = buildReviewerInfo(reviewer);
+  const normalizedCompleted = normalizeFields(previous.completedFields);
+  const normalizedRequested = normalizeFields(previous.requestedFields ?? previous.completedFields);
+
+  clearedKeys.forEach((key) => {
+    normalizedCompleted[key] = false;
+    normalizedRequested[key] = false;
+  });
+
+  const completedTrueCount = Object.values(normalizedCompleted).filter(Boolean).length;
+  const requestedTrueCount = Object.values(normalizedRequested).filter(Boolean).length;
+  const relevantTotal = Math.max(
+    requestedTrueCount,
+    completedTrueCount,
+    Object.keys(normalizedCompleted).length,
+    Object.keys(normalizedRequested).length,
+  );
+
+  const totalFields = clamp(relevantTotal || Object.keys(normalizedRequested).length || 4, 1, 10);
+  const completedCount = clamp(completedTrueCount, 0, totalFields);
+  const normalizedNotes = normalizeNotes(notes);
+  const nowIso = new Date().toISOString();
+
+  const historyEntry = createHistoryEntry({
+    request: previous,
+    reviewer: reviewerInfo,
+    status: 'reset',
+    notes: normalizedNotes,
+    completedFields: normalizedCompleted,
+    requestedFields: normalizedRequested,
+    clearedFields: clearedMap,
+  });
+
+  const previousHistory = sanitizeHistoryEntries(previous.history, previous);
+  const nextHistory = [historyEntry, ...previousHistory];
+
+  const nextRequest = {
+    ...previous,
+    status: completedTrueCount > 0 ? 'approved' : 'idle',
+    reviewerId: reviewerInfo.id,
+    reviewerName: reviewerInfo.name,
+    reviewerRole: reviewerInfo.role,
+    reviewedAt: nowIso,
+    updatedAt: nowIso,
+    completedFields: normalizedCompleted,
+    requestedFields: normalizedRequested,
+    completedCount,
+    totalFields,
+    notes: normalizedNotes,
+    history: nextHistory,
+  };
+
+  requests[index] = nextRequest;
+
+  const nextExtras = {
+    ...extras,
+    verificationRequests: requests,
+  };
+
+  saveExtras(owner.id, nextExtras);
+
+  try {
+    notifyAdminVerificationRequestsChanged({
+      type: 'reset',
+      requestId,
+      userId: owner.id,
+    });
+  } catch (error) {
+    console.warn('Failed to broadcast admin verification reset', error);
+  }
+
+  try {
+    appendAdminLog({
+      section: 'verification',
+      action: `Сбросил статусы модулей для запроса #${requestId}`,
+      adminId: reviewerInfo.id,
+      adminName: reviewerInfo.name,
+      role: reviewerInfo.role,
+      context: `verification:reset:${requestId}`,
+      metadata: {
+        requestId,
+        userId: owner.id,
+        clearedFields: clearedMap,
+      },
+    });
+  } catch (error) {
+    console.warn('Не удалось записать лог сброса верификации', error);
+  }
+
+  const clientForEntry = {
+    ...owner,
+    profile: {
+      ...owner.profile,
+      ...nextExtras,
+      verificationRequests: requests,
+    },
+  };
+
+  return buildRequestEntry(clientForEntry, nextRequest);
+};
+
+export const __internals = Object.freeze({
+  normalizeStatus,
+  normalizeFields,
+  parseTimestamp,
+  buildRequestEntry,
+  findRequestOwner,
+  ensureValidStatus,
+});

--- a/dodepus-casino/src/app/routes.jsx
+++ b/dodepus-casino/src/app/routes.jsx
@@ -33,6 +33,8 @@ import History from '../pages/profile/history';
 import Promos from '../pages/profile/promos';
 import Season from '../pages/profile/season';
 import GamesHistory from '../pages/profile/games-history';
+import Verification from '../pages/profile/verification';
+import AdminVerification from '../pages/Admin/verification';
 
 function RequireAuth({ children }) {
   const { isAuthed } = useAuth();
@@ -95,6 +97,7 @@ export default function AppRoutes() {
         <Route path="roles" element={<AdminRoles />} />
         <Route path="role-edit" element={<AdminRoleEdit />} />
         <Route path="transactions" element={<AdminTransactions />} />
+        <Route path="verification" element={<AdminVerification />} />
         <Route path="moderators-chat" element={<AdminModeratorsChat />} />
         <Route path="administrators-chat" element={<AdminAdministratorsChat />} />
         <Route path="staff-chat" element={<AdminStaffChat />} />
@@ -126,6 +129,7 @@ export default function AppRoutes() {
         <Route path="history" element={<History />} />
         <Route path="terminal" element={<Terminal />} />
         <Route path="personal" element={<Personal />} />
+        <Route path="verification" element={<Verification />} />
         <Route path="promos" element={<Promos />} />
         <Route path="season" element={<Season />} />
         <Route path="games-history" element={<GamesHistory />} />

--- a/dodepus-casino/src/pages/Admin/AdminLayout.jsx
+++ b/dodepus-casino/src/pages/Admin/AdminLayout.jsx
@@ -8,6 +8,7 @@ import { availableRoles, rolePermissionMatrix } from './roles/data/roleConfigs.j
 const NAV_ITEMS = [
   { key: 'overview', to: 'overview', label: 'Обзор', permission: 'overview' },
   { key: 'clients', to: 'clients', label: 'Клиенты', permission: 'clients' },
+  { key: 'verification', to: 'verification', label: 'Верификация', permission: 'verification' },
   { key: 'transactions', to: 'transactions', label: 'Транзакции', permission: 'transactions' },
   { key: 'divider-1', type: 'divider' },
   { key: 'promocodes', to: 'promocodes', label: 'Promo', permission: 'promocodes' },

--- a/dodepus-casino/src/pages/Admin/verification/Verification.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/Verification.jsx
@@ -1,0 +1,570 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import { Alert, Stack, Form } from 'react-bootstrap';
+import { useSearchParams } from 'react-router-dom';
+import { useAuth } from '../../../app/AuthContext.jsx';
+import {
+  updateVerificationRequestStatus,
+  resetVerificationRequestModules,
+} from '../../../../local-sim/admin/verification';
+import { useAdminVerificationRequests } from './hooks/useAdminVerificationRequests.js';
+import VerificationRequestsBlock from './blocks/VerificationRequestsBlock.jsx';
+import VerificationPartialBlock from './blocks/VerificationPartialBlock.jsx';
+import VerificationRejectedBlock from './blocks/VerificationRejectedBlock.jsx';
+import VerificationApprovedBlock from './blocks/VerificationApprovedBlock.jsx';
+import VerificationRequestModal from './components/VerificationRequestModal.jsx';
+import {
+  getAdminDisplayName,
+  getAdminId,
+  getAdminRole,
+  getUserDisplayName,
+} from './utils.js';
+import {
+  deriveModuleStatesFromRequests,
+  summarizeModuleStates,
+  VERIFICATION_MODULES,
+} from '../../../shared/verification/index.js';
+
+const parseTimestamp = (value) => {
+  if (!value) return 0;
+  try {
+    const parsed = Date.parse(value);
+    return Number.isFinite(parsed) ? parsed : 0;
+  } catch {
+    return 0;
+  }
+};
+
+const getRequestSortTimestamp = (request) => {
+  if (!request) return 0;
+  if (Number.isFinite(request.sortTimestamp)) {
+    return request.sortTimestamp;
+  }
+
+  const candidates = [request.updatedAt, request.reviewedAt, request.submittedAt];
+  for (const value of candidates) {
+    const ts = parseTimestamp(value);
+    if (ts) {
+      return ts;
+    }
+  }
+
+  return 0;
+};
+
+const buildUserEntries = (rawRequests = []) => {
+  const byUser = new Map();
+
+  rawRequests.forEach((request) => {
+    if (!request || typeof request !== 'object') {
+      return;
+    }
+
+    const userId = request.userId || request.id;
+    if (!userId) {
+      return;
+    }
+
+    if (!byUser.has(userId)) {
+      byUser.set(userId, []);
+    }
+    byUser.get(userId).push(request);
+  });
+
+  return Array.from(byUser.entries()).map(([userId, userRequests]) => {
+    const modulesMap = deriveModuleStatesFromRequests(userRequests);
+    const summary = summarizeModuleStates(modulesMap);
+    const sorted = userRequests
+      .slice()
+      .sort((a, b) => getRequestSortTimestamp(b) - getRequestSortTimestamp(a));
+
+    const findByStatus = (status) => sorted.find((request) => request?.status === status) || null;
+
+    const pendingRequest = findByStatus('pending');
+    const rejectedRequest = findByStatus('rejected');
+    const approvedRequest = findByStatus('approved');
+    const idleRequest = findByStatus('idle');
+    const latestRequest = sorted[0] || null;
+
+    const primaryRequest =
+      pendingRequest || rejectedRequest || approvedRequest || idleRequest || latestRequest;
+
+    const baseRequest = primaryRequest || latestRequest || null;
+    const normalizedUserId = baseRequest?.userId || userId || '';
+    const displayName = getUserDisplayName(baseRequest || { userId: normalizedUserId });
+
+    const searchIndex = [
+      normalizedUserId,
+      displayName,
+      baseRequest?.userEmail,
+      baseRequest?.userPhone,
+      baseRequest?.profile?.firstName,
+      baseRequest?.profile?.lastName,
+      baseRequest?.profile?.nickname,
+    ]
+      .filter(Boolean)
+      .map((value) => String(value).toLowerCase())
+      .join(' ');
+
+    const modules = VERIFICATION_MODULES.map((module) => ({
+      key: module.key,
+      label: module.label,
+      status: modulesMap[module.key]?.status || 'idle',
+    }));
+
+    const attachmentsCount = Array.isArray(primaryRequest?.attachments)
+      ? primaryRequest.attachments.length
+      : 0;
+
+    const section = summary.hasPending
+      ? 'requests'
+      : summary.hasRejected
+        ? 'rejected'
+        : summary.allApproved
+          ? 'verified'
+          : 'partial';
+
+    const sortTimestamp = Math.max(
+      summary.latestTimestamp || 0,
+      ...sorted.map((request) => getRequestSortTimestamp(request)),
+    );
+
+    return {
+      userId: normalizedUserId,
+      displayName,
+      modules,
+      modulesMap,
+      summary,
+      attachmentsCount,
+      primaryRequest,
+      pendingRequest,
+      rejectedRequest,
+      approvedRequest,
+      idleRequest,
+      latestRequest,
+      sortTimestamp,
+      searchIndex,
+      section,
+      submittedAt: primaryRequest?.submittedAt || '',
+      updatedAt: primaryRequest?.updatedAt || '',
+      reviewedAt: primaryRequest?.reviewedAt || '',
+      reviewer: primaryRequest?.reviewer || {},
+      status: primaryRequest?.status || '',
+    };
+  });
+};
+
+export default function Verification() {
+  const { requests, loading, error, reload, ensureLoaded } = useAdminVerificationRequests();
+  const { user } = useAuth();
+  const [actionError, setActionError] = useState(null);
+  const [busyId, setBusyId] = useState(null);
+  const createInitialModalState = useCallback(
+    () => ({
+      show: false,
+      requestId: null,
+      defaultMode: 'view',
+      moduleKey: null,
+      moduleStatus: null,
+    }),
+    [],
+  );
+  const [modalState, setModalState] = useState(() => createInitialModalState());
+  const [expandedSection, setExpandedSection] = useState(null);
+
+  useEffect(() => {
+    const maybePromise = ensureLoaded?.();
+    if (maybePromise && typeof maybePromise.catch === 'function') {
+      maybePromise.catch(() => {});
+    }
+  }, [ensureLoaded]);
+
+  const [searchParams, setSearchParams] = useSearchParams();
+  const [searchInput, setSearchInput] = useState(() => searchParams.get('q') || '');
+  const [searchQuery, setSearchQuery] = useState(() => searchParams.get('q') || '');
+  const normalizedSearch = searchQuery.trim().toLowerCase();
+
+  useEffect(() => {
+    const paramValue = searchParams.get('q') || '';
+    setSearchInput((current) => (current === paramValue ? current : paramValue));
+    setSearchQuery((current) => (current === paramValue ? current : paramValue));
+  }, [searchParams]);
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setSearchQuery(searchInput);
+
+      const nextQuery = searchInput.trim();
+      const currentQuery = searchParams.get('q') || '';
+      const hasParam = searchParams.has('q');
+
+      if (nextQuery === currentQuery) {
+        if ((nextQuery && hasParam) || (!nextQuery && !hasParam)) {
+          return;
+        }
+      }
+
+      const nextParams = new URLSearchParams(searchParams);
+      if (nextQuery) {
+        nextParams.set('q', nextQuery);
+      } else {
+        nextParams.delete('q');
+      }
+
+      setSearchParams(nextParams, { replace: true });
+    }, 400);
+
+    return () => clearTimeout(handler);
+  }, [searchInput, searchParams, setSearchParams]);
+
+  const userEntries = useMemo(
+    () => buildUserEntries(Array.isArray(requests) ? requests : []),
+    [requests],
+  );
+
+  const filteredEntries = useMemo(() => {
+    if (!normalizedSearch) {
+      return userEntries;
+    }
+    return userEntries.filter((entry) => entry.searchIndex.includes(normalizedSearch));
+  }, [userEntries, normalizedSearch]);
+
+  const grouped = useMemo(() => {
+    const buckets = {
+      requests: [],
+      partial: [],
+      rejected: [],
+      verified: [],
+    };
+
+    filteredEntries.forEach((entry) => {
+      buckets[entry.section].push(entry);
+    });
+
+    Object.values(buckets).forEach((items) => {
+      items.sort((a, b) => (b.sortTimestamp || 0) - (a.sortTimestamp || 0));
+    });
+
+    return buckets;
+  }, [filteredEntries]);
+
+  const activeRequest = useMemo(() => {
+    if (!modalState.requestId) {
+      return null;
+    }
+
+    if (!Array.isArray(requests)) {
+      return null;
+    }
+
+    return requests.find((entry) => entry?.id === modalState.requestId) || null;
+  }, [requests, modalState.requestId]);
+
+  const reviewer = useMemo(
+    () => ({
+      id: getAdminId(user),
+      name: getAdminDisplayName(user),
+      role: getAdminRole(user),
+    }),
+    [user],
+  );
+
+  const handleConfirm = useCallback(
+    async (request, payload = {}) => {
+      if (!request) return false;
+
+      setActionError(null);
+      setBusyId(request.id);
+
+      try {
+        await Promise.resolve(
+          updateVerificationRequestStatus({
+            requestId: request.id,
+            status: 'approved',
+            reviewer,
+            notes: payload.notes,
+            completedFields: payload.completedFields,
+            requestedFields: payload.requestedFields,
+            profilePatch: payload.profilePatch,
+          }),
+        );
+        const maybePromise = ensureLoaded?.();
+        if (maybePromise && typeof maybePromise.catch === 'function') {
+          maybePromise.catch(() => {});
+        }
+        return true;
+      } catch (err) {
+        const normalizedError =
+          err instanceof Error ? err : new Error('Не удалось обновить статус запроса');
+        setActionError(normalizedError);
+        return false;
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [ensureLoaded, reviewer],
+  );
+
+  const handleReject = useCallback(
+    async (request, payload = {}) => {
+      if (!request) return false;
+
+      setActionError(null);
+      setBusyId(request.id);
+
+      try {
+        await Promise.resolve(
+          updateVerificationRequestStatus({
+            requestId: request.id,
+            status: 'rejected',
+            reviewer,
+            notes: payload.notes,
+            completedFields: payload.completedFields,
+            requestedFields: payload.requestedFields,
+            profilePatch: payload.profilePatch,
+          }),
+        );
+        const maybePromise = ensureLoaded?.();
+        if (maybePromise && typeof maybePromise.catch === 'function') {
+          maybePromise.catch(() => {});
+        }
+        return true;
+      } catch (err) {
+        const normalizedError =
+          err instanceof Error ? err : new Error('Не удалось обновить статус запроса');
+        setActionError(normalizedError);
+        return false;
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [ensureLoaded, reviewer],
+  );
+
+  const openRequestModal = useCallback(
+    (request, options = {}) => {
+      if (!request) return;
+      const nextMode = (() => {
+        if (options.defaultMode) {
+          return options.defaultMode;
+        }
+        if (request.status === 'pending') {
+          return 'approve';
+        }
+        if (request.status === 'approved') {
+          return 'view';
+        }
+        return 'view';
+      })();
+
+      setModalState({
+        show: true,
+        requestId: request.id,
+        defaultMode: nextMode,
+        moduleKey: options.moduleKey || null,
+        moduleStatus: options.moduleStatus || null,
+      });
+    },
+    [],
+  );
+
+  const closeRequestModal = useCallback(() => {
+    if (busyId) {
+      return;
+    }
+    setModalState(createInitialModalState());
+  }, [busyId, createInitialModalState]);
+
+  const handleModalConfirm = useCallback(
+    async (payload) => {
+      if (!activeRequest) return;
+      const ok = await handleConfirm(activeRequest, payload);
+      if (ok) {
+        setModalState(createInitialModalState());
+      }
+    },
+    [activeRequest, handleConfirm, createInitialModalState],
+  );
+
+  const handleModalReject = useCallback(
+    async (payload) => {
+      if (!activeRequest) return;
+      const ok = await handleReject(activeRequest, payload);
+      if (ok) {
+        setModalState(createInitialModalState());
+      }
+    },
+    [activeRequest, handleReject, createInitialModalState],
+  );
+
+  const handleModalReset = useCallback(
+    async (payload) => {
+      if (!activeRequest) return;
+
+      setActionError(null);
+      setBusyId(activeRequest.id);
+
+      try {
+        await Promise.resolve(
+          resetVerificationRequestModules({
+            requestId: activeRequest.id,
+            modules: payload.modules,
+            notes: payload.notes,
+            reviewer,
+          }),
+        );
+        const maybePromise = ensureLoaded?.();
+        if (maybePromise && typeof maybePromise.catch === 'function') {
+          maybePromise.catch(() => {});
+        }
+        setModalState(createInitialModalState());
+      } catch (err) {
+        const normalizedError =
+          err instanceof Error ? err : new Error('Не удалось сбросить статусы модулей');
+        setActionError(normalizedError);
+      } finally {
+        setBusyId(null);
+      }
+    },
+    [activeRequest, reviewer, ensureLoaded, createInitialModalState],
+  );
+
+  const toggleSection = useCallback((section) => {
+    setExpandedSection((current) => (current === section ? null : section));
+  }, []);
+
+  const handleOpenEntry = useCallback(
+    (entry) => {
+      if (!entry) return;
+      const request =
+        entry.primaryRequest || entry.pendingRequest || entry.latestRequest || null;
+      if (!request) {
+        return;
+      }
+      openRequestModal(request, {
+        defaultMode: request.status === 'pending' ? 'approve' : 'view',
+      });
+    },
+    [openRequestModal],
+  );
+
+  const handleOpenModule = useCallback(
+    (entry, module) => {
+      if (!entry || !module) {
+        return;
+      }
+      const request =
+        entry.primaryRequest || entry.pendingRequest || entry.latestRequest || null;
+      if (!request) {
+        return;
+      }
+
+      const moduleStatus = module.status || 'idle';
+      const defaultMode =
+        request.status === 'pending' && moduleStatus !== 'approved' ? 'approve' : 'view';
+
+      openRequestModal(request, {
+        defaultMode,
+        moduleKey: module.key || null,
+        moduleStatus,
+      });
+    },
+    [openRequestModal],
+  );
+
+  const handleOpenReset = useCallback(
+    (entry) => {
+      if (!entry) return;
+      const request = entry.primaryRequest || entry.latestRequest || entry.approvedRequest || null;
+      if (!request) {
+        return;
+      }
+      openRequestModal(request, {
+        defaultMode: 'reset',
+      });
+    },
+    [openRequestModal],
+  );
+
+  const modalBusy = useMemo(() => {
+    if (!busyId || !activeRequest) {
+      return false;
+    }
+    return busyId === activeRequest.id;
+  }, [activeRequest, busyId]);
+
+  const displayError = actionError || error;
+
+  return (
+    <Stack gap={3}>
+      {displayError && (
+        <Alert variant="danger" className="mb-0">
+          {displayError.message}
+        </Alert>
+      )}
+
+      <Form className="mb-0" onSubmit={(event) => event.preventDefault()}>
+        <Form.Control
+          type="search"
+          placeholder="Поиск по ID, имени, фамилии, e-mail, телефону или никнейму"
+          value={searchInput}
+          onChange={(event) => setSearchInput(event.target.value)}
+        />
+      </Form>
+
+      <VerificationRequestsBlock
+        requests={grouped.requests}
+        loading={loading}
+        onReload={reload}
+        onOpen={handleOpenEntry}
+        onOpenModule={handleOpenModule}
+        expanded={expandedSection === 'requests'}
+        onToggle={() => toggleSection('requests')}
+      />
+
+      <VerificationPartialBlock
+        requests={grouped.partial}
+        loading={loading}
+        onReload={reload}
+        onOpen={handleOpenEntry}
+        onOpenModule={handleOpenModule}
+        expanded={expandedSection === 'partial'}
+        onToggle={() => toggleSection('partial')}
+      />
+
+      <VerificationRejectedBlock
+        requests={grouped.rejected}
+        loading={loading}
+        onReload={reload}
+        onOpen={handleOpenEntry}
+        onOpenModule={handleOpenModule}
+        expanded={expandedSection === 'rejected'}
+        onToggle={() => toggleSection('rejected')}
+      />
+
+      <VerificationApprovedBlock
+        requests={grouped.verified}
+        loading={loading}
+        onReload={reload}
+        onOpen={handleOpenEntry}
+        onOpenModule={handleOpenModule}
+        onReset={handleOpenReset}
+        expanded={expandedSection === 'verified'}
+        onToggle={() => toggleSection('verified')}
+      />
+
+      <VerificationRequestModal
+        show={modalState.show && Boolean(activeRequest)}
+        request={activeRequest}
+        onClose={closeRequestModal}
+        onConfirm={handleModalConfirm}
+        onReject={handleModalReject}
+        onReset={handleModalReset}
+        busy={modalBusy}
+        defaultMode={modalState.defaultMode}
+        focusModule={modalState.moduleKey}
+        focusStatus={modalState.moduleStatus}
+      />
+    </Stack>
+  );
+}
+

--- a/dodepus-casino/src/pages/Admin/verification/blocks/VerificationApprovedBlock.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/blocks/VerificationApprovedBlock.jsx
@@ -1,0 +1,144 @@
+import { Badge, Button, Card, Collapse, ListGroup, Spinner } from 'react-bootstrap';
+import { ChevronDown } from 'lucide-react';
+import VerificationFieldBadges from '../components/VerificationFieldBadges.jsx';
+import { formatDateTime } from '../utils.js';
+
+export default function VerificationApprovedBlock({
+  requests = [],
+  loading = false,
+  onReload,
+  onOpen,
+  onOpenModule,
+  onReset,
+  expanded = false,
+  onToggle,
+}) {
+  const totalRequests = Array.isArray(requests) ? requests.length : 0;
+
+  const handleOpen = (entry) => {
+    if (!onOpen) return;
+    onOpen(entry);
+  };
+
+  const handleModuleOpen = (entry, module, event) => {
+    event?.stopPropagation?.();
+    if (!onOpenModule) return;
+    onOpenModule(entry, module);
+  };
+
+  const handleReset = (entry, event) => {
+    event?.stopPropagation?.();
+    if (!onReset) return;
+    onReset(entry);
+  };
+
+  const sectionId = 'verification-approved';
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Header className="bg-body-tertiary py-3">
+        <div className="d-flex align-items-center justify-content-between gap-3">
+          <button
+            type="button"
+            className="btn btn-link text-decoration-none text-body flex-grow-1 text-start"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-controls={`${sectionId}-content`}
+          >
+            <span className="d-inline-flex align-items-center gap-3">
+              <ChevronDown
+                size={18}
+                className="flex-shrink-0"
+                style={{
+                  transition: 'transform 0.2s ease',
+                  transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                }}
+              />
+              <span className="fw-semibold">Верифицировано</span>
+              <Badge bg="success">{totalRequests}</Badge>
+            </span>
+          </button>
+          {onReload && (
+            <Button variant="outline-primary" onClick={onReload} disabled={loading}>
+              {loading ? (
+                <>
+                  <Spinner size="sm" animation="border" className="me-2" />
+                  Обновление…
+                </>
+              ) : (
+                'Обновить'
+              )}
+            </Button>
+          )}
+        </div>
+      </Card.Header>
+
+      <Collapse in={expanded}>
+        <div id={`${sectionId}-content`}>
+          <Card.Body className="border-top">
+            <Card.Text className="text-muted mb-0">
+              Пользователи с полностью подтверждёнными модулями. Все данные проверены.
+            </Card.Text>
+          </Card.Body>
+
+          {totalRequests === 0 ? (
+            <Card.Body className="border-top text-secondary small">
+              {loading ? 'Загрузка…' : 'Пока нет завершённых проверок.'}
+            </Card.Body>
+          ) : (
+            <ListGroup variant="flush" className="border-top">
+              {requests.map((entry) => (
+                <ListGroup.Item
+                  key={entry.primaryRequest?.id || entry.userId}
+                  className="py-3"
+                  action={Boolean(onOpen)}
+                  onClick={() => handleOpen(entry)}
+                  style={onOpen ? { cursor: 'pointer' } : undefined}
+                >
+                  <div className="d-flex flex-column flex-xl-row gap-3 align-items-xl-start justify-content-between">
+                    <div className="flex-grow-1">
+                      <div className="fw-semibold">{entry.userId}</div>
+                      <div className="mt-3">
+                        <VerificationFieldBadges
+                          modules={entry.modules}
+                          onSelect={(module, event) => handleModuleOpen(entry, module, event)}
+                        />
+                      </div>
+                    </div>
+                    <div className="text-xl-center" style={{ minWidth: 140 }}>
+                      <div className="fw-medium">
+                        {entry.summary.approved} / {entry.summary.total}
+                      </div>
+                      <div className="text-muted small">Подтверждено</div>
+                    </div>
+                    <div className="text-xl-end" style={{ minWidth: 200 }}>
+                      <div className="text-muted small">Дата подтверждения</div>
+                      <div className="fw-medium">{formatDateTime(entry.reviewedAt)}</div>
+                      {entry?.reviewer?.name && (
+                        <div className="text-muted small">{entry.reviewer.name}</div>
+                      )}
+                    </div>
+                    <div
+                      className="d-flex flex-column align-items-stretch align-items-xl-end gap-2"
+                      style={{ minWidth: 180 }}
+                    >
+                      {onReset && (
+                        <Button
+                          variant="outline-danger"
+                          size="sm"
+                          onClick={(event) => handleReset(entry, event)}
+                        >
+                          Сбросить статусы
+                        </Button>
+                      )}
+                    </div>
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )}
+        </div>
+      </Collapse>
+    </Card>
+  );
+}

--- a/dodepus-casino/src/pages/Admin/verification/blocks/VerificationPartialBlock.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/blocks/VerificationPartialBlock.jsx
@@ -1,0 +1,120 @@
+import { Badge, Button, Card, Collapse, ListGroup, Spinner } from 'react-bootstrap';
+import { ChevronDown } from 'lucide-react';
+import VerificationFieldBadges from '../components/VerificationFieldBadges.jsx';
+import { formatDateTime } from '../utils.js';
+
+export default function VerificationPartialBlock({
+  requests = [],
+  loading = false,
+  onReload,
+  onOpen,
+  onOpenModule,
+  expanded = false,
+  onToggle,
+}) {
+  const totalRequests = Array.isArray(requests) ? requests.length : 0;
+
+  const handleOpen = (entry) => {
+    if (!onOpen) return;
+    onOpen(entry);
+  };
+
+  const handleModuleOpen = (entry, module, event) => {
+    event?.stopPropagation?.();
+    if (!onOpenModule) return;
+    onOpenModule(entry, module);
+  };
+
+  const sectionId = 'verification-partial';
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Header className="bg-body-tertiary py-3">
+        <div className="d-flex align-items-center justify-content-between gap-3">
+          <button
+            type="button"
+            className="btn btn-link text-decoration-none text-body flex-grow-1 text-start"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-controls={`${sectionId}-content`}
+          >
+            <span className="d-inline-flex align-items-center gap-3">
+              <ChevronDown
+                size={18}
+                className="flex-shrink-0"
+                style={{
+                  transition: 'transform 0.2s ease',
+                  transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                }}
+              />
+              <span className="fw-semibold">Частичная верификация</span>
+              <Badge bg="secondary">{totalRequests}</Badge>
+            </span>
+          </button>
+          {onReload && (
+            <Button variant="outline-primary" onClick={onReload} disabled={loading}>
+              {loading ? (
+                <>
+                  <Spinner size="sm" animation="border" className="me-2" />
+                  Обновление…
+                </>
+              ) : (
+                'Обновить'
+              )}
+            </Button>
+          )}
+        </div>
+      </Card.Header>
+
+      <Collapse in={expanded}>
+        <div id={`${sectionId}-content`}>
+          <Card.Body className="border-top">
+            <Card.Text className="text-muted mb-0">
+              Пользователи с частично подтверждёнными модулями. Проверьте новые данные и завершите процесс.
+            </Card.Text>
+          </Card.Body>
+
+          {totalRequests === 0 ? (
+            <Card.Body className="border-top text-secondary small">
+              {loading ? 'Загрузка…' : 'Нет запросов на частичную проверку.'}
+            </Card.Body>
+          ) : (
+            <ListGroup variant="flush" className="border-top">
+              {requests.map((entry) => (
+                <ListGroup.Item
+                  key={entry.primaryRequest?.id || entry.userId}
+                  className="py-3"
+                  action={Boolean(onOpen)}
+                  onClick={() => handleOpen(entry)}
+                  style={onOpen ? { cursor: 'pointer' } : undefined}
+                >
+                  <div className="d-flex flex-column flex-xl-row gap-3 align-items-xl-start justify-content-between">
+                    <div className="flex-grow-1">
+                      <div className="fw-semibold">{entry.userId}</div>
+                      <div className="mt-3">
+                        <VerificationFieldBadges
+                          modules={entry.modules}
+                          onSelect={(module, event) => handleModuleOpen(entry, module, event)}
+                        />
+                      </div>
+                    </div>
+                    <div className="text-xl-center" style={{ minWidth: 140 }}>
+                      <div className="fw-medium">
+                        {entry.summary.approved} / {entry.summary.total}
+                      </div>
+                      <div className="text-muted small">Подтверждено</div>
+                    </div>
+                    <div className="text-xl-end" style={{ minWidth: 200 }}>
+                      <div className="text-muted small">Последнее обновление</div>
+                      <div className="fw-medium">{formatDateTime(entry.updatedAt)}</div>
+                    </div>
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )}
+        </div>
+      </Collapse>
+    </Card>
+  );
+}

--- a/dodepus-casino/src/pages/Admin/verification/blocks/VerificationRejectedBlock.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/blocks/VerificationRejectedBlock.jsx
@@ -1,0 +1,123 @@
+import { Badge, Button, Card, Collapse, ListGroup, Spinner } from 'react-bootstrap';
+import { ChevronDown } from 'lucide-react';
+import VerificationFieldBadges from '../components/VerificationFieldBadges.jsx';
+import { formatDateTime } from '../utils.js';
+
+export default function VerificationRejectedBlock({
+  requests = [],
+  loading = false,
+  onReload,
+  onOpen,
+  onOpenModule,
+  expanded = false,
+  onToggle,
+}) {
+  const totalRequests = Array.isArray(requests) ? requests.length : 0;
+
+  const handleOpen = (entry) => {
+    if (!onOpen) return;
+    onOpen(entry);
+  };
+
+  const handleModuleOpen = (entry, module, event) => {
+    event?.stopPropagation?.();
+    if (!onOpenModule) return;
+    onOpenModule(entry, module);
+  };
+
+  const sectionId = 'verification-rejected';
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Header className="bg-body-tertiary py-3">
+        <div className="d-flex align-items-center justify-content-between gap-3">
+          <button
+            type="button"
+            className="btn btn-link text-decoration-none text-body flex-grow-1 text-start"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-controls={`${sectionId}-content`}
+          >
+            <span className="d-inline-flex align-items-center gap-3">
+              <ChevronDown
+                size={18}
+                className="flex-shrink-0"
+                style={{
+                  transition: 'transform 0.2s ease',
+                  transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                }}
+              />
+              <span className="fw-semibold">Отказано</span>
+              <Badge bg="secondary">{totalRequests}</Badge>
+            </span>
+          </button>
+          {onReload && (
+            <Button variant="outline-primary" onClick={onReload} disabled={loading}>
+              {loading ? (
+                <>
+                  <Spinner size="sm" animation="border" className="me-2" />
+                  Обновление…
+                </>
+              ) : (
+                'Обновить'
+              )}
+            </Button>
+          )}
+        </div>
+      </Card.Header>
+
+      <Collapse in={expanded}>
+        <div id={`${sectionId}-content`}>
+          <Card.Body className="border-top">
+            <Card.Text className="text-muted mb-0">
+              Пользователи с отклонёнными модулями. Требуется повторная отправка данных.
+            </Card.Text>
+          </Card.Body>
+
+          {totalRequests === 0 ? (
+            <Card.Body className="border-top text-secondary small">
+              {loading ? 'Загрузка…' : 'Отказов нет.'}
+            </Card.Body>
+          ) : (
+            <ListGroup variant="flush" className="border-top">
+              {requests.map((entry) => (
+                <ListGroup.Item
+                  key={entry.primaryRequest?.id || entry.userId}
+                  className="py-3"
+                  action={Boolean(onOpen)}
+                  onClick={() => handleOpen(entry)}
+                  style={onOpen ? { cursor: 'pointer' } : undefined}
+                >
+                  <div className="d-flex flex-column flex-xl-row gap-3 align-items-xl-start justify-content-between">
+                    <div className="flex-grow-1">
+                      <div className="fw-semibold">{entry.userId}</div>
+                      <div className="mt-3">
+                        <VerificationFieldBadges
+                          modules={entry.modules}
+                          onSelect={(module, event) => handleModuleOpen(entry, module, event)}
+                        />
+                      </div>
+                    </div>
+                    <div className="text-xl-center" style={{ minWidth: 200 }}>
+                      <div className="text-muted small">Дата решения</div>
+                      <div className="fw-medium">{formatDateTime(entry.reviewedAt)}</div>
+                    </div>
+                    {entry?.reviewer?.name && (
+                      <div className="text-xl-end" style={{ minWidth: 200 }}>
+                        <div className="text-muted small">Проверил</div>
+                        <div className="fw-medium">{entry.reviewer.name}</div>
+                        {entry.reviewer.role && (
+                          <div className="text-muted small">{entry.reviewer.role}</div>
+                        )}
+                      </div>
+                    )}
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )}
+        </div>
+      </Collapse>
+    </Card>
+  );
+}

--- a/dodepus-casino/src/pages/Admin/verification/blocks/VerificationRequestsBlock.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/blocks/VerificationRequestsBlock.jsx
@@ -1,0 +1,128 @@
+import { Badge, Button, Card, Collapse, ListGroup, Spinner } from 'react-bootstrap';
+import { ChevronDown } from 'lucide-react';
+import VerificationFieldBadges from '../components/VerificationFieldBadges.jsx';
+import { formatDateTime, getInReviewVerificationVariant } from '../utils.js';
+
+export default function VerificationRequestsBlock({
+  requests = [],
+  loading = false,
+  onReload,
+  onOpen,
+  onOpenModule,
+  expanded = false,
+  onToggle,
+}) {
+  const totalRequests = Array.isArray(requests) ? requests.length : 0;
+  const inReviewBadgeVariant = getInReviewVerificationVariant(totalRequests);
+  const handleOpen = (entry) => {
+    if (!onOpen) return;
+    onOpen(entry);
+  };
+
+  const handleModuleOpen = (entry, module, event) => {
+    event?.stopPropagation?.();
+    if (!onOpenModule) return;
+    onOpenModule(entry, module);
+  };
+
+  const sectionId = 'verification-requests';
+
+  return (
+    <Card className="shadow-sm">
+      <Card.Header className="bg-body-tertiary py-3">
+        <div className="d-flex align-items-center justify-content-between gap-3">
+          <button
+            type="button"
+            className="btn btn-link text-decoration-none text-body flex-grow-1 text-start"
+            onClick={onToggle}
+            aria-expanded={expanded}
+            aria-controls={`${sectionId}-content`}
+          >
+              <span className="d-inline-flex align-items-center gap-3">
+                <ChevronDown
+                  size={18}
+                  className="flex-shrink-0"
+                  style={{
+                    transition: 'transform 0.2s ease',
+                    transform: expanded ? 'rotate(180deg)' : 'rotate(0deg)',
+                  }}
+                />
+                <span className="fw-semibold">Запросы на верификацию</span>
+                <Badge bg={inReviewBadgeVariant}>{totalRequests}</Badge>
+              </span>
+          </button>
+          {onReload && (
+            <Button variant="outline-primary" onClick={onReload} disabled={loading}>
+              {loading ? (
+                <>
+                  <Spinner size="sm" animation="border" className="me-2" />
+                  Обновление…
+                </>
+              ) : (
+                'Обновить'
+              )}
+            </Button>
+          )}
+        </div>
+      </Card.Header>
+
+      <Collapse in={expanded}>
+        <div id={`${sectionId}-content`}>
+          <Card.Body className="border-top">
+            <Card.Text className="text-muted mb-0">
+              Новые запросы от пользователей, ожидающие проверки администратором.
+            </Card.Text>
+          </Card.Body>
+
+          {totalRequests === 0 ? (
+            <Card.Body className="border-top text-secondary small">
+              {loading ? 'Загрузка запросов…' : 'Новых запросов нет.'}
+            </Card.Body>
+          ) : (
+            <ListGroup variant="flush" className="border-top">
+              {requests.map((entry) => (
+                <ListGroup.Item
+                  key={entry.primaryRequest?.id || entry.userId}
+                  className="py-3"
+                  action={Boolean(onOpen)}
+                  onClick={() => handleOpen(entry)}
+                  style={onOpen ? { cursor: 'pointer' } : undefined}
+                >
+                  <div className="d-flex flex-column flex-xl-row gap-3 align-items-xl-start justify-content-between">
+                    <div className="flex-grow-1">
+                      <div className="fw-semibold">{entry.userId}</div>
+                      <div className="mt-3">
+                        <VerificationFieldBadges
+                          modules={entry.modules}
+                          onSelect={(module, event) => handleModuleOpen(entry, module, event)}
+                        />
+                      </div>
+                    </div>
+                    <div className="text-xl-center" style={{ minWidth: 140 }}>
+                      <div className="fw-medium">
+                        {entry.summary.approved} / {entry.summary.total}
+                      </div>
+                      <div className="text-muted small">Готово</div>
+                      <div className="text-muted small mt-2">
+                        Документов: {entry.attachmentsCount}
+                      </div>
+                    </div>
+                    <div className="text-xl-end" style={{ minWidth: 200 }}>
+                      <div className="text-muted small">Отправлено</div>
+                      <div className="fw-medium">{formatDateTime(entry.submittedAt)}</div>
+                      {entry.updatedAt && entry.updatedAt !== entry.submittedAt && (
+                        <div className="text-muted small">
+                          Обновлено {formatDateTime(entry.updatedAt)}
+                        </div>
+                      )}
+                    </div>
+                  </div>
+                </ListGroup.Item>
+              ))}
+            </ListGroup>
+          )}
+        </div>
+      </Collapse>
+    </Card>
+  );
+}

--- a/dodepus-casino/src/pages/Admin/verification/components/VerificationFieldBadges.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/components/VerificationFieldBadges.jsx
@@ -1,0 +1,94 @@
+import { Badge, Button } from 'react-bootstrap';
+import { Circle, CircleHelp, CheckCircle2, CircleX } from 'lucide-react';
+import { VERIFICATION_MODULES } from '../../../../shared/verification/index.js';
+
+const ICON_CONFIG = {
+  approved: { Component: CheckCircle2, className: 'text-success' },
+  pending: { Component: CircleHelp, className: 'text-warning' },
+  rejected: { Component: CircleX, className: 'text-danger' },
+  idle: { Component: Circle, className: 'text-secondary' },
+};
+
+const STATE_VARIANT = {
+  approved: 'success',
+  pending: 'warning',
+  rejected: 'danger',
+  idle: 'secondary',
+};
+
+const STATE_BUTTON_VARIANT = {
+  approved: 'success',
+  pending: 'warning',
+  rejected: 'danger',
+  idle: 'secondary',
+};
+
+export default function VerificationFieldBadges({ modules, onSelect }) {
+  const items = Array.isArray(modules)
+    ? modules
+    : VERIFICATION_MODULES.map((module) => ({ ...module, status: 'idle' }));
+
+  if (typeof onSelect === 'function') {
+    return (
+      <div className="d-flex flex-wrap gap-2">
+        {items.map((item) => {
+          const state = item.status || 'idle';
+          const config = ICON_CONFIG[state] || ICON_CONFIG.idle;
+          const IconComponent = config.Component;
+          const disabled = state === 'idle';
+
+          const handleClick = (event) => {
+            event?.stopPropagation?.();
+            if (disabled) {
+              return;
+            }
+            onSelect?.(item, event);
+          };
+
+          return (
+            <Button
+              key={item.key}
+              type="button"
+              size="sm"
+              variant={STATE_BUTTON_VARIANT[state] || 'secondary'}
+              className="d-inline-flex align-items-center gap-2 px-3"
+              onClick={handleClick}
+              disabled={disabled}
+            >
+              <IconComponent
+                size={16}
+                className={config.className}
+                style={config.style}
+              />
+              <span>{item.label}</span>
+            </Button>
+          );
+        })}
+      </div>
+    );
+  }
+
+  return (
+    <div className="d-flex flex-wrap gap-2">
+      {items.map((item) => {
+        const state = item.status || 'idle';
+        const config = ICON_CONFIG[state] || ICON_CONFIG.idle;
+        const IconComponent = config.Component;
+        return (
+          <Badge
+            key={item.key}
+            bg={STATE_VARIANT[state] || 'secondary'}
+            className="fw-normal d-inline-flex align-items-center gap-2"
+          >
+            <IconComponent
+              size={16}
+              className={config.className}
+              style={config.style}
+            />
+            <span>{item.label}</span>
+          </Badge>
+        );
+      })}
+    </div>
+  );
+}

--- a/dodepus-casino/src/pages/Admin/verification/components/VerificationRequestModal.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/components/VerificationRequestModal.jsx
@@ -1,0 +1,1046 @@
+import { useCallback, useEffect, useMemo, useState } from 'react';
+import {
+  Modal,
+  Button,
+  Form,
+  Badge,
+  Stack,
+  Row,
+  Col,
+  ListGroup,
+  Placeholder,
+  Alert,
+} from 'react-bootstrap';
+import { Eye } from 'lucide-react';
+import { FIELD_LABELS, formatDateTime, getStatusLabel } from '../utils.js';
+
+const EMPTY_FIELDS = Object.freeze({ email: false, phone: false, address: false, doc: false });
+const FIELD_KEYS = Object.freeze(Object.keys(FIELD_LABELS));
+
+const normalizeFieldState = (fields = {}) => ({
+  email: Boolean(fields?.email),
+  phone: Boolean(fields?.phone),
+  address: Boolean(fields?.address),
+  doc: Boolean(fields?.doc),
+});
+
+const normalizeGenderValue = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (!normalized) {
+    return '';
+  }
+
+  if (['male', 'm', 'man', 'м', 'м.', 'муж', 'муж.', 'мужчина', 'мужской'].includes(normalized)) {
+    return 'male';
+  }
+
+  if (
+    ['female', 'f', 'woman', 'ж', 'ж.', 'жен', 'жен.', 'женщина', 'женский'].includes(
+      normalized,
+    )
+  ) {
+    return 'female';
+  }
+
+  if (
+    [
+      'unspecified',
+      'не указан',
+      'не указано',
+      'не выбрано',
+      'не выбран',
+      'не выбрана',
+      'unknown',
+      'другое',
+      'other',
+    ].includes(normalized)
+  ) {
+    return '';
+  }
+
+  return '';
+};
+
+const buildCompletedSelection = (request) => {
+  if (!request) {
+    return { ...EMPTY_FIELDS };
+  }
+
+  const completed = normalizeFieldState(request.completedFields);
+  const requested = normalizeFieldState(request.requestedFields);
+
+  const next = { ...EMPTY_FIELDS };
+
+  FIELD_KEYS.forEach((key) => {
+    if (completed[key]) {
+      next[key] = true;
+      return;
+    }
+
+    if (requested[key]) {
+      next[key] = false;
+    }
+  });
+
+  return next;
+};
+
+const buildRejectedSelection = (request) => {
+  if (!request) {
+    return { ...EMPTY_FIELDS };
+  }
+
+  const requested = normalizeFieldState(request.requestedFields);
+  const completed = normalizeFieldState(request.completedFields);
+
+  const next = { ...EMPTY_FIELDS };
+
+  FIELD_KEYS.forEach((key) => {
+    if (requested[key] && !completed[key]) {
+      next[key] = true;
+    }
+  });
+
+  return next;
+};
+
+const buildProfileDraft = (request) => {
+  const source = request?.profile ?? {};
+  return {
+    address: source.address || '',
+    city: source.city || '',
+    country: source.country || '',
+    firstName: source.firstName || '',
+    lastName: source.lastName || '',
+    dob: source.dob || '',
+    gender: normalizeGenderValue(source.gender),
+  };
+};
+
+const buildResetSelection = (request, { focusKey } = {}) => {
+  const completed = normalizeFieldState(request?.completedFields);
+  const next = { ...EMPTY_FIELDS };
+  FIELD_KEYS.forEach((key) => {
+    if (focusKey && focusKey === key && completed[key]) {
+      next[key] = true;
+    } else {
+      next[key] = false;
+    }
+  });
+  return next;
+};
+
+const formatFileSize = (value) => {
+  const numeric = Number(value);
+  if (!Number.isFinite(numeric) || numeric <= 0) {
+    return '';
+  }
+
+  if (numeric >= 1024 * 1024) {
+    return `${(numeric / (1024 * 1024)).toFixed(1)} МБ`;
+  }
+
+  if (numeric >= 1024) {
+    return `${(numeric / 1024).toFixed(1)} КБ`;
+  }
+
+  return `${numeric} Б`;
+};
+
+const GENDER_OPTIONS = [
+  { value: '', label: 'Не выбран' },
+  { value: 'male', label: 'Мужчина' },
+  { value: 'female', label: 'Женщина' },
+];
+
+const STATUS_VARIANT = Object.freeze({
+  pending: 'warning',
+  rejected: 'danger',
+  approved: 'success',
+  idle: 'secondary',
+});
+
+const MODULE_STATUS_LABELS = Object.freeze({
+  idle: 'Нет запроса',
+  pending: 'На проверке',
+  approved: 'Подтверждено',
+  rejected: 'Отказано',
+});
+
+export default function VerificationRequestModal({
+  show = false,
+  request = null,
+  onClose,
+  onConfirm,
+  onReject,
+  onReset,
+  busy = false,
+  defaultMode = 'approve',
+  focusModule = null,
+  focusStatus = null,
+}) {
+  const status = request?.status;
+  const isPending = status === 'pending';
+
+  const normalizedDefaultMode = useMemo(() => {
+    if (defaultMode === 'reset') {
+      return 'reset';
+    }
+    if (!isPending) {
+      return 'view';
+    }
+    if (defaultMode === 'reject') {
+      return 'reject';
+    }
+    if (defaultMode === 'view') {
+      return 'view';
+    }
+    return 'approve';
+  }, [isPending, defaultMode]);
+
+  const [mode, setMode] = useState(normalizedDefaultMode);
+  const [completedSelection, setCompletedSelection] = useState(() =>
+    buildCompletedSelection(request),
+  );
+  const [rejectedSelection, setRejectedSelection] = useState(() =>
+    buildRejectedSelection(request),
+  );
+  const [resetSelection, setResetSelection] = useState(() =>
+    buildResetSelection(request, { focusKey: focusModule }),
+  );
+  const [notes, setNotes] = useState(() => request?.notes || '');
+  const [profileDraft, setProfileDraft] = useState(() => buildProfileDraft(request));
+  const [formError, setFormError] = useState('');
+  const [historyLimit, setHistoryLimit] = useState(3);
+  const [highlightKey, setHighlightKey] = useState('');
+
+  const requestedFields = useMemo(() => normalizeFieldState(request?.requestedFields), [request]);
+  const completedFields = useMemo(() => normalizeFieldState(request?.completedFields), [request]);
+  const allowMultiReset = useMemo(
+    () => defaultMode === 'reset' && !focusModule,
+    [defaultMode, focusModule],
+  );
+  const activeModuleKey = useMemo(() => {
+    if (focusModule && FIELD_KEYS.includes(focusModule)) {
+      return focusModule;
+    }
+    const requestedKey = FIELD_KEYS.find((key) => requestedFields[key]);
+    if (requestedKey) {
+      return requestedKey;
+    }
+    const completedKey = FIELD_KEYS.find((key) => completedFields[key]);
+    if (completedKey) {
+      return completedKey;
+    }
+    return FIELD_KEYS[0];
+  }, [focusModule, requestedFields, completedFields]);
+  const resetEligibleKeys = useMemo(() => {
+    const completedKeys = FIELD_KEYS.filter((key) => completedFields[key]);
+    if (allowMultiReset) {
+      return completedKeys;
+    }
+    if (activeModuleKey && completedFields[activeModuleKey]) {
+      return [activeModuleKey];
+    }
+    return [];
+  }, [allowMultiReset, completedFields, activeModuleKey]);
+  const projectToActive = useCallback(
+    (selection) => {
+      const projected = { ...EMPTY_FIELDS };
+      if (activeModuleKey) {
+        projected[activeModuleKey] = Boolean(selection?.[activeModuleKey]);
+      }
+      return projected;
+    },
+    [activeModuleKey],
+  );
+
+  const isResetMode = mode === 'reset';
+  const isReadOnly = !isPending && !isResetMode;
+
+  useEffect(() => {
+    const completedSnapshot = normalizeFieldState(request?.completedFields);
+    const hasEligibleReset = Boolean(activeModuleKey && completedSnapshot[activeModuleKey]);
+
+    const nextMode = (() => {
+      if (defaultMode === 'reset' && hasEligibleReset && typeof onReset === 'function') {
+        return 'reset';
+      }
+      if (request?.status === 'pending') {
+        return normalizedDefaultMode;
+      }
+      return 'view';
+    })();
+
+    setMode(nextMode);
+
+    const nextCompleted = buildCompletedSelection(request);
+    setCompletedSelection(projectToActive(nextCompleted));
+
+    const nextRejected = buildRejectedSelection(request);
+    setRejectedSelection(projectToActive(nextRejected));
+
+    setResetSelection(
+      buildResetSelection(request, {
+        focusKey:
+          hasEligibleReset && !allowMultiReset ? activeModuleKey : undefined,
+      }),
+    );
+    setNotes(request?.notes || '');
+    setProfileDraft(buildProfileDraft(request));
+    setFormError('');
+    setHistoryLimit(3);
+  }, [
+    request,
+    normalizedDefaultMode,
+    defaultMode,
+    activeModuleKey,
+    onReset,
+    projectToActive,
+    allowMultiReset,
+  ]);
+
+  useEffect(() => {
+    if (!show) {
+      setFormError('');
+    }
+  }, [show]);
+
+  useEffect(() => {
+    if (!show || !activeModuleKey) {
+      setHighlightKey('');
+      return;
+    }
+
+    setHighlightKey(activeModuleKey);
+
+    if (typeof document !== 'undefined') {
+      const element = document.getElementById(`verification-field-${activeModuleKey}`);
+      if (element && typeof element.scrollIntoView === 'function') {
+        setTimeout(() => {
+          element.scrollIntoView({ block: 'center', behavior: 'smooth' });
+        }, 120);
+      }
+    }
+
+    const timer = setTimeout(() => setHighlightKey(''), 1800);
+    return () => clearTimeout(timer);
+  }, [show, activeModuleKey]);
+
+  const canReset = useMemo(
+    () => typeof onReset === 'function' && resetEligibleKeys.length > 0,
+    [onReset, resetEligibleKeys.length],
+  );
+  const hasResetSelection = useMemo(
+    () => resetEligibleKeys.some((key) => resetSelection[key]),
+    [resetEligibleKeys, resetSelection],
+  );
+  const trimmedNotes = notes.trim();
+
+  const canEditProfile = isPending && (mode === 'approve' || mode === 'reject');
+  const activeSelection = mode === 'reject' ? rejectedSelection : completedSelection;
+  const hasCompletedSelection = useMemo(
+    () => Object.values(completedSelection).some(Boolean),
+    [completedSelection],
+  );
+  const hasRejectedSelection = useMemo(
+    () => Object.values(rejectedSelection).some(Boolean),
+    [rejectedSelection],
+  );
+
+  const readOnlyNotice = useMemo(() => {
+    if (isResetMode) {
+      return 'Выберите подтверждённый модуль, который необходимо вернуть в статус «Не отправлено».';
+    }
+
+    if (isPending) {
+      if (mode === 'view') {
+        return 'Просмотр модульной проверки. Нажмите «Начать проверку», чтобы изменить статус.';
+      }
+      return '';
+    }
+
+    switch (status) {
+      case 'approved':
+        return 'Запрос уже подтверждён. Редактирование и изменение решения недоступны.';
+      case 'rejected':
+        return 'Запрос отклонён. Изменение данных доступно только после новой отправки от пользователя.';
+      case 'idle':
+        return 'Редактирование доступно только для новых запросов на верификацию.';
+      default:
+        return 'Редактирование доступно только для новых запросов на верификацию.';
+    }
+  }, [isPending, isResetMode, mode, status]);
+
+  const handleToggleField = (key) => {
+    if (key !== activeModuleKey) {
+      return;
+    }
+
+    if (busy || mode === 'view' || isReadOnly || mode === 'reset') {
+      return;
+    }
+
+    setFormError('');
+
+    if (mode === 'reject') {
+      setRejectedSelection((prev) => ({
+        ...prev,
+        [key]: !prev[key],
+      }));
+      return;
+    }
+
+    setCompletedSelection((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  const handleResetToggle = (key) => {
+    if (!isResetMode || busy) {
+      return;
+    }
+
+    if (!resetEligibleKeys.includes(key)) {
+      return;
+    }
+
+    setFormError('');
+    setResetSelection((prev) => ({
+      ...prev,
+      [key]: !prev[key],
+    }));
+  };
+
+  const handleProfileChange = (key, value) => {
+    if (!canEditProfile) return;
+    setProfileDraft((prev) => ({
+      ...prev,
+      [key]: key === 'gender' ? normalizeGenderValue(value) : value,
+    }));
+  };
+
+  const handleConfirm = () => {
+    if (!request || !isPending) return;
+
+    if (mode === 'reject') {
+      setMode('approve');
+      setFormError('');
+      return;
+    }
+
+    if (!hasCompletedSelection) {
+      setFormError('Отметьте модуль, который готов к подтверждению.');
+      return;
+    }
+
+    if (!trimmedNotes) {
+      setFormError('Добавьте комментарий перед подтверждением.');
+      return;
+    }
+
+    onConfirm?.({
+      completedFields: completedSelection,
+      notes: trimmedNotes,
+      profilePatch: profileDraft,
+    });
+  };
+
+  const enterRejectMode = () => {
+    if (!isPending) {
+      return;
+    }
+    setMode('reject');
+    setRejectedSelection(projectToActive(buildRejectedSelection(request)));
+    setFormError('');
+  };
+
+  const handleReject = () => {
+    if (!request || !isPending) return;
+
+    if (mode !== 'reject') {
+      enterRejectMode();
+      return;
+    }
+
+    if (!hasRejectedSelection) {
+      setFormError('Укажите, требуется ли отказ по модулю.');
+      return;
+    }
+
+    if (!trimmedNotes) {
+      setFormError('Добавьте комментарий перед отказом.');
+      return;
+    }
+
+    onReject?.({
+      requestedFields: rejectedSelection,
+      notes: trimmedNotes,
+      profilePatch: profileDraft,
+    });
+  };
+
+  const handleCancelReject = () => {
+    setMode(isPending ? 'approve' : 'view');
+    setRejectedSelection(projectToActive(buildRejectedSelection(request)));
+    setFormError('');
+  };
+
+  const enterApproveMode = () => {
+    if (!isPending) {
+      return;
+    }
+    setMode('approve');
+    setFormError('');
+  };
+
+  const enterResetMode = () => {
+    if (!canReset) {
+      return;
+    }
+    setMode('reset');
+    setFormError('');
+    setResetSelection(
+      buildResetSelection(request, {
+        focusKey: allowMultiReset ? undefined : activeModuleKey,
+      }),
+    );
+  };
+
+  const handleCancelReset = () => {
+    setMode('view');
+    setFormError('');
+    setResetSelection(
+      buildResetSelection(request, {
+        focusKey: allowMultiReset ? undefined : activeModuleKey,
+      }),
+    );
+  };
+
+  const handleResetSubmit = () => {
+    if (!request || !isResetMode || !canReset) {
+      return;
+    }
+
+    if (!hasResetSelection) {
+      setFormError('Выберите модуль для сброса статуса.');
+      return;
+    }
+
+    if (!trimmedNotes) {
+      setFormError('Добавьте комментарий перед сбросом статусов.');
+      return;
+    }
+
+    onReset?.({
+      modules: resetSelection,
+      notes: trimmedNotes,
+    });
+  };
+
+  const statusVariant = STATUS_VARIANT[request?.status] || 'secondary';
+
+  const historyEntries = useMemo(() => {
+    if (!Array.isArray(request?.history)) {
+      return [];
+    }
+    return request.history;
+  }, [request]);
+
+  const visibleHistory = historyEntries.slice(0, historyLimit);
+  const remainingHistory = Math.max(historyEntries.length - historyLimit, 0);
+  const handleExpandHistory = () => {
+    setHistoryLimit((prev) => Math.min(prev + 10, historyEntries.length));
+  };
+
+  const attachments = Array.isArray(request?.attachments) ? request.attachments : [];
+  const visibleFieldKeys = useMemo(
+    () => (activeModuleKey ? [activeModuleKey] : FIELD_KEYS),
+    [activeModuleKey],
+  );
+  const activeModuleStatus = useMemo(() => {
+    if (!activeModuleKey) {
+      return focusStatus || '';
+    }
+    if (focusStatus && focusModule === activeModuleKey) {
+      return focusStatus;
+    }
+    if (completedFields[activeModuleKey]) {
+      return 'approved';
+    }
+    if (status === 'rejected') {
+      return 'rejected';
+    }
+    if (requestedFields[activeModuleKey]) {
+      return 'pending';
+    }
+    return 'idle';
+  }, [
+    activeModuleKey,
+    focusStatus,
+    focusModule,
+    completedFields,
+    requestedFields,
+    status,
+  ]);
+
+  const renderFieldLabel = (key) => {
+    if (mode === 'reject') {
+      return activeSelection[key] ? 'Отказ по пункту' : 'Оставить без изменений';
+    }
+
+    return activeSelection[key] ? 'Готово' : 'Требует проверки';
+  };
+
+  const isFieldToggleDisabled = (key) => {
+    if (busy || mode === 'view' || isReadOnly || mode === 'reset') {
+      return true;
+    }
+
+    if (mode === 'approve') {
+      const isRequested = requestedFields[key];
+      const isCompleted = completedFields[key];
+      return !isRequested && !isCompleted;
+    }
+
+    return false;
+  };
+
+  return (
+    <Modal show={show} onHide={onClose} size="lg" centered backdrop="static">
+      <Modal.Header closeButton={!busy}>
+        <Modal.Title className="d-flex flex-column gap-1">
+          <span>Верификация аккаунта {request?.userId ?? '—'}</span>
+          <Badge bg={statusVariant} className="align-self-start">
+            {getStatusLabel(request?.status)}
+          </Badge>
+          {activeModuleKey ? (
+            <span className="text-muted small">
+              Модуль: {FIELD_LABELS[activeModuleKey] || '—'}
+              {activeModuleStatus
+                ? ` · ${
+                    MODULE_STATUS_LABELS[activeModuleStatus] ||
+                    MODULE_STATUS_LABELS.pending
+                  }`
+                : ''}
+            </span>
+          ) : null}
+        </Modal.Title>
+      </Modal.Header>
+
+      <Modal.Body>
+        {!request ? (
+          <Placeholder as="div" animation="glow">
+            <Placeholder xs={12} className="mb-2" />
+            <Placeholder xs={10} className="mb-2" />
+            <Placeholder xs={8} className="mb-2" />
+          </Placeholder>
+        ) : (
+          <Stack gap={4}>
+            <section>
+              <h5 className="mb-3">Контакты и статус</h5>
+              <Row className="g-3">
+                <Col xs={12} md={6}>
+                  <div className="text-muted small">Почта</div>
+                  <div>{request.userEmail || '—'}</div>
+                </Col>
+                <Col xs={12} md={6}>
+                  <div className="text-muted small">Телефон</div>
+                  <div>{request.userPhone || '—'}</div>
+                </Col>
+                <Col xs={12} md={6}>
+                  <div className="text-muted small">Отправлено</div>
+                  <div>{formatDateTime(request.submittedAt)}</div>
+                </Col>
+                <Col xs={12} md={6}>
+                  <div className="text-muted small">Обновлено</div>
+                  <div>{formatDateTime(request.updatedAt)}</div>
+                </Col>
+              </Row>
+            </section>
+
+            <section>
+              <h5 className="mb-3">Поля для проверки</h5>
+              <Stack gap={3}>
+                {formError ? (
+                  <Alert variant="danger" className="mb-0">
+                    {formError}
+                  </Alert>
+                ) : null}
+                {mode === 'reject' ? (
+                  <Alert variant="warning" className="mb-0">
+                    Укажите, требуется ли отказ по модулю.
+                  </Alert>
+                ) : null}
+                {readOnlyNotice ? (
+                  <Alert variant="secondary" className="mb-0">
+                    {readOnlyNotice}
+                  </Alert>
+                ) : null}
+
+                {visibleFieldKeys.map((key) => {
+                  const label = FIELD_LABELS[key];
+                  const isRequested = requestedFields[key];
+                  const isHighlighted = highlightKey === key;
+                  const fieldClassName = [
+                    'rounded p-3',
+                    isHighlighted ? 'border border-2 border-primary shadow-sm' : 'border',
+                  ].join(' ');
+                  return (
+                    <div
+                      key={key}
+                      id={`verification-field-${key}`}
+                      className={fieldClassName}
+                    >
+                      <div className="d-flex flex-column flex-md-row justify-content-between gap-3">
+                        <div>
+                          <div className="fw-semibold">{label}</div>
+                          <div className="text-muted small">
+                            {isRequested
+                              ? 'Запрошено администратором'
+                              : 'Не запрошено'}
+                          </div>
+                        </div>
+                        <Form.Check
+                          type="switch"
+                          id={`verify-${key}`}
+                          label={renderFieldLabel(key)}
+                          checked={Boolean(activeSelection[key])}
+                          disabled={isFieldToggleDisabled(key)}
+                          onChange={() => handleToggleField(key)}
+                        />
+                      </div>
+
+                      {key === 'address' ? (
+                        <Row className="g-2 mt-3">
+                          <Col xs={12}>
+                            <Form.Label className="small text-muted">Адрес</Form.Label>
+                            <Form.Control
+                              value={profileDraft.address}
+                              onChange={(event) =>
+                                handleProfileChange('address', event.target.value)
+                              }
+                              placeholder="Введите адрес клиента"
+                              disabled={busy || !canEditProfile}
+                            />
+                          </Col>
+                          <Col xs={12} md={6}>
+                            <Form.Label className="small text-muted">Город</Form.Label>
+                            <Form.Control
+                              value={profileDraft.city}
+                              onChange={(event) =>
+                                handleProfileChange('city', event.target.value)
+                              }
+                              placeholder="Город"
+                              disabled={busy || !canEditProfile}
+                            />
+                          </Col>
+                          <Col xs={12} md={6}>
+                            <Form.Label className="small text-muted">Страна</Form.Label>
+                            <Form.Control
+                              value={profileDraft.country}
+                              onChange={(event) =>
+                                handleProfileChange('country', event.target.value)
+                              }
+                              placeholder="Страна"
+                              disabled={busy || !canEditProfile}
+                            />
+                          </Col>
+                        </Row>
+                      ) : null}
+
+                      {key === 'doc' ? (
+                        <Row className="g-2 mt-3">
+                          <Col xs={12} md={6}>
+                            <Form.Label className="small text-muted">Имя</Form.Label>
+                            <Form.Control
+                              value={profileDraft.firstName}
+                              onChange={(event) =>
+                                handleProfileChange('firstName', event.target.value)
+                              }
+                              placeholder="Имя"
+                              disabled={busy || !canEditProfile}
+                            />
+                          </Col>
+                          <Col xs={12} md={6}>
+                            <Form.Label className="small text-muted">Фамилия</Form.Label>
+                            <Form.Control
+                              value={profileDraft.lastName}
+                              onChange={(event) =>
+                                handleProfileChange('lastName', event.target.value)
+                              }
+                              placeholder="Фамилия"
+                              disabled={busy || !canEditProfile}
+                            />
+                          </Col>
+                          <Col xs={12} md={6}>
+                            <Form.Label className="small text-muted">Дата рождения</Form.Label>
+                            <Form.Control
+                              type="date"
+                              value={profileDraft.dob || ''}
+                              onChange={(event) => handleProfileChange('dob', event.target.value)}
+                              disabled={busy || !canEditProfile}
+                            />
+                          </Col>
+                          <Col xs={12} md={6}>
+                            <Form.Label className="small text-muted">Пол</Form.Label>
+                            <Form.Select
+                              value={profileDraft.gender || ''}
+                              onChange={(event) => handleProfileChange('gender', event.target.value)}
+                              disabled={busy || !canEditProfile}
+                            >
+                              {GENDER_OPTIONS.map((option) => (
+                                <option key={option.value} value={option.value}>
+                                  {option.label}
+                                </option>
+                              ))}
+                            </Form.Select>
+                          </Col>
+                        </Row>
+                      ) : null}
+                    </div>
+                  );
+                })}
+
+                {isResetMode ? (
+                  <div className="mt-3">
+                    <h6 className="fw-semibold mb-2">
+                      {allowMultiReset
+                        ? 'Выберите модули для сброса'
+                        : 'Выберите модуль для сброса'}
+                    </h6>
+                    {resetEligibleKeys.length === 0 ? (
+                      <div className="text-muted small">
+                        Нет подтверждённых модулей для сброса.
+                      </div>
+                    ) : (
+                      <Stack gap={2}>
+                        {resetEligibleKeys.map((key) => (
+                          <Form.Check
+                            key={`reset-${key}`}
+                            type="checkbox"
+                            id={`reset-${key}`}
+                            label={FIELD_LABELS[key]}
+                            checked={Boolean(resetSelection[key])}
+                            disabled={busy}
+                            onChange={() => handleResetToggle(key)}
+                          />
+                        ))}
+                      </Stack>
+                    )}
+                    <Form.Text className="text-muted d-block mt-2">
+                      После сброса выбранные пункты снова станут доступны пользователю для редактирования и повторной отправки.
+                    </Form.Text>
+                  </div>
+                ) : null}
+              </Stack>
+            </section>
+
+            {attachments.length > 0 && isPending ? (
+              <section>
+                <h5 className="mb-3">Документы пользователя</h5>
+                <ListGroup>
+                  {attachments.map((file) => {
+                    const previewUrl = (() => {
+                      if (typeof file?.previewUrl === 'string' && file.previewUrl) {
+                        return file.previewUrl;
+                      }
+                      if (typeof file?.dataUrl === 'string' && file.dataUrl) {
+                        return file.dataUrl;
+                      }
+                      if (typeof file?.url === 'string' && file.url) {
+                        return file.url;
+                      }
+                      if (typeof file?.path === 'string' && file.path) {
+                        return file.path;
+                      }
+                      return '';
+                    })();
+
+                    return (
+                      <ListGroup.Item key={file.id || file.name}>
+                        <div className="d-flex flex-column flex-lg-row justify-content-between gap-3">
+                          <div className="flex-grow-1">
+                            <div className="fw-semibold">{file.name || 'document'}</div>
+                            {file.documentLabel ? (
+                              <div className="text-muted small">{file.documentLabel}</div>
+                            ) : null}
+                            <div className="text-muted small">
+                              {file.type ? `${file.type} · ` : ''}
+                              {formatFileSize(file.size)}
+                            </div>
+                          </div>
+                          <div className="d-flex flex-column align-items-start align-items-lg-end gap-2">
+                            <div className="text-muted small">
+                              Загружено {formatDateTime(file.uploadedAt)}
+                            </div>
+                            {previewUrl ? (
+                              <Button
+                                as="a"
+                                href={previewUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                variant="outline-primary"
+                                size="sm"
+                              >
+                                <Eye size={16} className="me-2" /> Просмотреть
+                              </Button>
+                            ) : (
+                              <div className="text-muted small">Предпросмотр недоступен</div>
+                            )}
+                          </div>
+                        </div>
+                      </ListGroup.Item>
+                    );
+                  })}
+                </ListGroup>
+              </section>
+            ) : null}
+            {!isPending && attachments.length > 0 ? (
+              <Alert variant="secondary" className="mb-0">
+                Документы доступны для просмотра только в новых запросах на верификацию.
+              </Alert>
+            ) : null}
+
+            <section>
+              <h5 className="mb-3">Комментарий администратора</h5>
+              <Form.Control
+                as="textarea"
+                rows={3}
+                value={notes}
+                onChange={(event) => setNotes(event.target.value)}
+                placeholder="Добавьте комментарий к решению"
+                disabled={busy || (!canEditProfile && !isResetMode)}
+              />
+            </section>
+
+            {visibleHistory.length > 0 ? (
+              <section>
+                <div className="d-flex align-items-center justify-content-between mb-3">
+                  <h5 className="mb-0">История решений</h5>
+                  {remainingHistory > 0 ? (
+                    <Button
+                      variant="link"
+                      className="p-0"
+                      onClick={handleExpandHistory}
+                    >
+                      Развернуть (+ ещё {Math.min(remainingHistory, 10)} комментариев)
+                    </Button>
+                  ) : null}
+                </div>
+                <ListGroup variant="flush">
+                  {visibleHistory.map((entry) => (
+                    <ListGroup.Item key={entry.id} className="px-0">
+                      <div className="d-flex flex-column flex-lg-row gap-3 justify-content-between">
+                        <div>
+                          <div className="fw-semibold">{entry.reviewer?.name || 'Администратор'}</div>
+                          <div className="text-muted small">
+                            {formatDateTime(entry.updatedAt)} · {getStatusLabel(entry.status)}
+                          </div>
+                        </div>
+                        <div className="flex-grow-1">
+                          {entry.notes ? (
+                            <div className="text-body">{entry.notes}</div>
+                          ) : (
+                            <div className="text-muted small">Без комментария</div>
+                          )}
+                        </div>
+                      </div>
+                    </ListGroup.Item>
+                  ))}
+                </ListGroup>
+              </section>
+            ) : null}
+          </Stack>
+        )}
+      </Modal.Body>
+
+      <Modal.Footer className="justify-content-between flex-column flex-md-row gap-2">
+        <Button variant="outline-secondary" onClick={onClose} disabled={busy}>
+          Назад
+        </Button>
+        <div className="d-flex flex-column flex-sm-row gap-2 align-items-stretch">
+          {isResetMode ? (
+            <>
+              <Button
+                variant="link"
+                className="text-decoration-none"
+                onClick={handleCancelReset}
+                disabled={busy}
+              >
+                Отменить сброс
+              </Button>
+              <Button
+                variant="danger"
+                onClick={handleResetSubmit}
+                disabled={busy || !hasResetSelection || !trimmedNotes}
+              >
+                Сбросить статусы
+              </Button>
+            </>
+          ) : (
+            <>
+              {mode === 'reject' && isPending ? (
+                <Button
+                  variant="link"
+                  className="text-decoration-none"
+                  onClick={handleCancelReject}
+                  disabled={busy}
+                >
+                  Отменить отказ
+                </Button>
+              ) : null}
+              {isPending ? (
+                <>
+                  <Button
+                    variant="outline-danger"
+                    onClick={handleReject}
+                    disabled={busy || !request}
+                  >
+                    {mode === 'reject' ? 'Подтвердить отказ' : 'Отказать'}
+                  </Button>
+                  {mode === 'view' ? (
+                    <Button
+                      variant="primary"
+                      onClick={enterApproveMode}
+                      disabled={busy || !request}
+                    >
+                      Начать проверку
+                    </Button>
+                  ) : (
+                    <Button
+                      variant="success"
+                      onClick={handleConfirm}
+                      disabled={
+                        busy ||
+                        !request ||
+                        mode !== 'approve' ||
+                        !hasCompletedSelection ||
+                        !trimmedNotes
+                      }
+                    >
+                      Подтвердить
+                    </Button>
+                  )}
+                </>
+              ) : canReset ? (
+                <Button
+                  variant="outline-danger"
+                  onClick={enterResetMode}
+                  disabled={busy || !canReset}
+                >
+                  Сбросить статусы
+                </Button>
+              ) : null}
+            </>
+          )}
+        </div>
+      </Modal.Footer>
+    </Modal>
+  );
+}

--- a/dodepus-casino/src/pages/Admin/verification/hooks/useAdminVerificationRequests.js
+++ b/dodepus-casino/src/pages/Admin/verification/hooks/useAdminVerificationRequests.js
@@ -1,0 +1,124 @@
+import { useCallback, useEffect, useRef, useState } from 'react';
+import {
+  listAdminVerificationRequests,
+  subscribeToAdminVerificationRequests,
+} from '../../../../../local-sim/admin/verification';
+
+const STORAGE_KEY_PREFIX = 'dodepus_profile_v1:';
+
+export function useAdminVerificationRequests() {
+  const [requests, setRequests] = useState([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState(null);
+  const [initialized, setInitialized] = useState(false);
+  const isMountedRef = useRef(true);
+  const activeRequestsRef = useRef(0);
+
+  useEffect(() => {
+    isMountedRef.current = true;
+
+    return () => {
+      isMountedRef.current = false;
+    };
+  }, []);
+
+  const loadRequests = useCallback(
+    async ({ signal, showLoader = true } = {}) => {
+      if (!isMountedRef.current) {
+        return;
+      }
+
+      if (showLoader) {
+        activeRequestsRef.current += 1;
+        setLoading(true);
+        setError(null);
+      }
+
+      try {
+        const data = await listAdminVerificationRequests({ signal });
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        setRequests(Array.isArray(data) ? data : []);
+        setError(null);
+      } catch (err) {
+        if (!isMountedRef.current) {
+          return;
+        }
+
+        if (err?.name !== 'AbortError') {
+          const normalizedError =
+            err instanceof Error
+              ? err
+              : new Error('Не удалось загрузить запросы на верификацию');
+          setError(normalizedError);
+        }
+      } finally {
+        if (!isMountedRef.current) {
+          activeRequestsRef.current = 0;
+        } else if (showLoader) {
+          activeRequestsRef.current = Math.max(0, activeRequestsRef.current - 1);
+          if (activeRequestsRef.current === 0) {
+            setLoading(false);
+          }
+        }
+      }
+    },
+    [],
+  );
+
+  useEffect(() => {
+    if (!initialized) {
+      return () => {};
+    }
+
+    const unsubscribe = subscribeToAdminVerificationRequests(() => {
+      loadRequests({ showLoader: false }).catch(() => {});
+    });
+
+    const target = typeof window !== 'undefined' ? window : null;
+    if (!target?.addEventListener) {
+      return () => {
+        unsubscribe();
+      };
+    }
+
+    const handleStorage = (event) => {
+      if (typeof event?.key !== 'string') {
+        return;
+      }
+
+      if (!event.key.startsWith(STORAGE_KEY_PREFIX)) {
+        return;
+      }
+
+      loadRequests({ showLoader: false }).catch(() => {});
+    };
+
+    target.addEventListener('storage', handleStorage);
+
+    return () => {
+      unsubscribe();
+      target.removeEventListener('storage', handleStorage);
+    };
+  }, [initialized, loadRequests]);
+
+  const startLoading = useCallback(
+    async (options = {}) => {
+      if (!initialized) {
+        setInitialized(true);
+      }
+
+      const showLoader = options?.showLoader ?? true;
+
+      return loadRequests({ ...options, showLoader });
+    },
+    [initialized, loadRequests],
+  );
+
+  const ensureLoaded = useCallback(() => startLoading(), [startLoading]);
+  const reload = useCallback(() => startLoading(), [startLoading]);
+
+  return { requests, loading, error, reload, ensureLoaded, initialized };
+}

--- a/dodepus-casino/src/pages/Admin/verification/index.js
+++ b/dodepus-casino/src/pages/Admin/verification/index.js
@@ -1,0 +1,1 @@
+export { default } from './Verification.jsx';

--- a/dodepus-casino/src/pages/Admin/verification/utils.js
+++ b/dodepus-casino/src/pages/Admin/verification/utils.js
@@ -1,0 +1,134 @@
+const ensureString = (value) => (typeof value === 'string' ? value.trim() : '');
+
+export const FIELD_LABELS = Object.freeze({
+  email: 'Почта',
+  phone: 'Телефон',
+  address: 'Адрес',
+  doc: 'Документы',
+});
+
+export const formatDateTime = (value, { withTime = true } = {}) => {
+  if (!value) return '—';
+
+  try {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      if (withTime) {
+        return date.toLocaleString('ru-RU');
+      }
+      return date.toLocaleDateString('ru-RU');
+    }
+  } catch (error) {
+    console.warn('Failed to format verification date', error);
+  }
+
+  return value;
+};
+
+export const getUserDisplayName = (request = {}) => {
+  const nickname = ensureString(request.userNickname);
+  if (nickname) return nickname;
+
+  const email = ensureString(request.userEmail);
+  if (email) return email;
+
+  const phone = ensureString(request.userPhone);
+  if (phone) return phone;
+
+  return `ID ${ensureString(request.userId) || 'неизвестно'}`;
+};
+
+export const getAdminId = (user) => {
+  const id = ensureString(user?.id) || ensureString(user?.user_metadata?.id);
+  return id || 'UNKNOWN';
+};
+
+export const getAdminDisplayName = (user) => {
+  const fullName = [ensureString(user?.firstName), ensureString(user?.lastName)]
+    .filter(Boolean)
+    .join(' ')
+    .trim();
+
+  if (fullName) {
+    return fullName;
+  }
+
+  const nickname = ensureString(user?.nickname);
+  if (nickname) {
+    return nickname;
+  }
+
+  const email = ensureString(user?.email);
+  if (email) {
+    return email;
+  }
+
+  return 'Неизвестный админ';
+};
+
+export const getAdminRole = (user) => {
+  const role = ensureString(user?.role);
+  if (role) return role;
+
+  if (Array.isArray(user?.roles)) {
+    const candidate = user.roles
+      .map((entry) => ensureString(entry))
+      .find((entry) => Boolean(entry));
+    if (candidate) {
+      return candidate;
+    }
+  }
+
+  const metadataRole = ensureString(user?.user_metadata?.role) || ensureString(user?.app_metadata?.role);
+  if (metadataRole) {
+    return metadataRole;
+  }
+
+  return 'admin';
+};
+
+export const getStatusLabel = (status) => {
+  switch (status) {
+    case 'waiting':
+    case 'idle':
+      return 'Нет запроса';
+    case 'in_review':
+    case 'pending':
+      return 'На проверке';
+    case 'approved':
+      return 'Подтверждено';
+    case 'rejected':
+      return 'Отказано';
+    case 'reset':
+      return 'Статусы сброшены';
+    default:
+      return 'На проверке';
+  }
+};
+
+const toFiniteNumber = (value) => {
+  const numeric = Number(value);
+  return Number.isFinite(numeric) ? numeric : 0;
+};
+
+export const getInReviewVerificationVariant = (count) => {
+  const numeric = Math.max(0, toFiniteNumber(count));
+  if (numeric >= 16) {
+    return 'danger';
+  }
+  if (numeric >= 10) {
+    return 'warning';
+  }
+  return 'success';
+};
+
+export const getInReviewVerificationTextClass = (count) => {
+  const variant = getInReviewVerificationVariant(count);
+  if (variant === 'danger') {
+    return 'text-danger';
+  }
+  if (variant === 'warning') {
+    return 'text-warning';
+  }
+  return 'text-success';
+};

--- a/dodepus-casino/src/pages/profile/layout/ProfileLayout.jsx
+++ b/dodepus-casino/src/pages/profile/layout/ProfileLayout.jsx
@@ -1,11 +1,34 @@
 import { Container, Row, Col, Nav, Badge } from 'react-bootstrap';
 import { NavLink, Outlet } from 'react-router-dom';
 import { useAuth } from '../../../app/AuthContext.jsx';
+import { useVerificationModules } from '../../../shared/verification/index.js';
 
 export default function ProfileLayout() {
   const { user } = useAuth();
   const currency = user?.currency || 'USD';
   const balance = user?.balance ?? 0;
+  const { summary: verificationSummary = {} } = useVerificationModules(user);
+
+  const verificationApproved = Number.isFinite(verificationSummary?.approved)
+    ? verificationSummary.approved
+    : 0;
+  const verificationTotal = Number.isFinite(verificationSummary?.total)
+    ? verificationSummary.total
+    : 4;
+  const verificationBadgeVariant = verificationSummary?.hasRejected
+    ? 'danger'
+    : verificationSummary?.hasPending
+      ? 'warning'
+      : verificationSummary?.allApproved
+        ? 'success'
+        : 'secondary';
+  const verificationLabelClass = verificationSummary?.hasRejected
+    ? 'text-danger fw-semibold'
+    : verificationSummary?.hasPending
+      ? 'text-warning fw-semibold'
+      : verificationSummary?.allApproved
+        ? 'text-success'
+        : '';
 
   const fmt = (v) =>
     new Intl.NumberFormat('ru-RU', { style: 'currency', currency }).format(v);
@@ -42,6 +65,19 @@ export default function ProfileLayout() {
               {/* ПЕРСОНАЛЬНЫЕ ДАННЫЕ */}
               <Nav.Link as={NavLink} end to="personal">
                 Персональные данные
+              </Nav.Link>
+
+              <Nav.Link
+                as={NavLink}
+                to="verification"
+                className="d-flex justify-content-between align-items-center"
+              >
+                <span className={verificationLabelClass.trim() || undefined}>
+                  Верификация
+                </span>
+                <Badge bg={verificationBadgeVariant}>
+                  {verificationApproved} / {verificationTotal}
+                </Badge>
               </Nav.Link>
 
               {/* разделитель */}

--- a/dodepus-casino/src/pages/profile/verification/Verification.jsx
+++ b/dodepus-casino/src/pages/profile/verification/Verification.jsx
@@ -1,0 +1,15 @@
+import {
+  VerificationStatusBlock,
+  VerificationUploadBlock,
+  VerificationHistoryBlock,
+} from './blocks';
+
+export default function Verification() {
+  return (
+    <div className="d-grid gap-4">
+      <VerificationStatusBlock />
+      <VerificationUploadBlock />
+      <VerificationHistoryBlock />
+    </div>
+  );
+}

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationHistoryBlock/VerificationHistoryBlock.jsx
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationHistoryBlock/VerificationHistoryBlock.jsx
@@ -1,0 +1,143 @@
+import { useMemo } from 'react';
+import { Card, Table } from 'react-bootstrap';
+import { useAuth } from '../../../../../app/AuthContext.jsx';
+import {
+  buildVerificationTimeline,
+  formatModuleList,
+  VERIFICATION_STATUS_LABELS,
+} from '../../../../../shared/verification/index.js';
+
+const DOCUMENT_TYPE_LABELS = Object.freeze({
+  internet_statement: 'Интернет-выписка',
+  bank_statement: 'Банковская выписка',
+  id_card: 'ID-карта',
+  foreign_passport: 'Заграничный паспорт',
+  internal_passport: 'Внутренний паспорт',
+  residence_permit: 'Вид на жительство',
+});
+
+const CATEGORY_LABELS = Object.freeze({
+  address: 'Подтверждение адреса',
+  identity: 'Подтверждение личности',
+});
+
+const getCategoryLabel = (upload) => {
+  const raw =
+    upload?.verificationCategory ||
+    upload?.verificationKind ||
+    upload?.category ||
+    upload?.kind;
+  return CATEGORY_LABELS[String(raw).toLowerCase()] || 'Документ';
+};
+
+const getDocumentLabel = (upload) => {
+  if (!upload || typeof upload !== 'object') return 'Документ';
+  const label =
+    upload.documentLabel ||
+    upload.verificationLabel ||
+    DOCUMENT_TYPE_LABELS[String(upload.documentType || upload.verificationType).toLowerCase()];
+  return label || 'Документ';
+};
+
+const formatDateTime = (value) => {
+  if (!value) return '—';
+  try {
+    const date = new Date(value);
+    if (!Number.isNaN(date.getTime())) {
+      return date.toLocaleString('ru-RU');
+    }
+  } catch (error) {
+    console.warn('Failed to format verification history date', error);
+  }
+  return value || '—';
+};
+
+const getStatusLabel = (event) => {
+  if (event.type === 'submitted') {
+    return 'Запрос отправлен';
+  }
+
+  if (event.type === 'reset' || event.status === 'reset') {
+    return 'Статусы сброшены';
+  }
+
+  const status = String(event.status || '').toLowerCase();
+  return VERIFICATION_STATUS_LABELS[status] || 'Обновление';
+};
+
+export default function VerificationHistoryBlock() {
+  const ctx = useAuth?.() || {};
+  const user = ctx.user || ctx.auth || {};
+  const uploads = Array.isArray(user?.verificationUploads) ? user.verificationUploads : [];
+  const timeline = useMemo(
+    () => buildVerificationTimeline(user?.verificationRequests),
+    [user?.verificationRequests],
+  );
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title className="mb-3">История</Card.Title>
+
+        <div className="d-grid gap-4">
+          <div>
+            <h6 className="fw-semibold mb-2">Решения и заявки</h6>
+            {timeline.length === 0 ? (
+              <div className="text-secondary">История пока отсутствует.</div>
+            ) : (
+              <Table responsive hover className="mb-0">
+                <thead>
+                  <tr>
+                    <th style={{ width: 220 }}>Когда</th>
+                    <th style={{ width: 220 }}>Статус</th>
+                    <th style={{ width: 220 }}>Модули</th>
+                    <th>Комментарий</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {timeline.map((event) => (
+                    <tr key={event.id}>
+                      <td>{formatDateTime(event.updatedAt)}</td>
+                      <td>{getStatusLabel(event)}</td>
+                      <td>{formatModuleList(event.modules) || '—'}</td>
+                      <td>{event.notes ? <span>{event.notes}</span> : <span className="text-secondary">—</span>}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            )}
+          </div>
+
+          <div>
+            <h6 className="fw-semibold mb-2">Загруженные документы</h6>
+            {uploads.length === 0 ? (
+              <div className="text-secondary">Пока нет загрузок.</div>
+            ) : (
+              <Table responsive hover className="mb-0">
+                <thead>
+                  <tr>
+                    <th style={{ width: 220 }}>Когда</th>
+                    <th style={{ width: 220 }}>Назначение</th>
+                    <th>Документ</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {uploads.map((u) => (
+                    <tr key={u.id}>
+                      <td>{formatDateTime(u.uploadedAt)}</td>
+                      <td>{getCategoryLabel(u)}</td>
+                      <td>
+                        <div className="fw-medium">{getDocumentLabel(u)}</div>
+                        <div className="text-secondary small text-truncate">{u.name}</div>
+                      </td>
+                    </tr>
+                  ))}
+                </tbody>
+              </Table>
+            )}
+          </div>
+        </div>
+      </Card.Body>
+    </Card>
+  );
+}

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationHistoryBlock/index.js
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationHistoryBlock/index.js
@@ -1,0 +1,1 @@
+export { default } from './VerificationHistoryBlock.jsx';

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationStatusBlock/VerificationStatusBlock.jsx
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationStatusBlock/VerificationStatusBlock.jsx
@@ -1,0 +1,317 @@
+import { useState } from 'react';
+import { Row, Col, Card, Button, Toast, ToastContainer, Alert } from 'react-bootstrap';
+import { Circle, CheckCircle, CircleHelp, CircleX } from 'lucide-react';
+import { useNavigate } from 'react-router-dom';
+import { useAuth } from '../../../../../app/AuthContext.jsx';
+import {
+  VERIFICATION_MODULES,
+  useVerificationModules,
+} from '../../../../../shared/verification/index.js';
+
+const ICON_LABELS = Object.freeze({
+  idle: 'требуется подтверждение',
+  pending: 'на проверке',
+  rejected: 'отклонено',
+  approved: 'подтверждено',
+});
+
+const ICON_BG_CLASS = Object.freeze({
+  idle: 'bg-secondary-subtle border-secondary-subtle',
+  pending: 'bg-warning-subtle border-warning-subtle',
+  rejected: 'bg-danger-subtle border-danger-subtle',
+  approved: 'bg-success-subtle border-success-subtle',
+});
+
+const ICON_COMPONENT = Object.freeze({
+  idle: (size) => <Circle size={size} className="text-secondary" />,
+  pending: (size) => <CircleHelp size={size} className="text-warning" />,
+  rejected: (size) => <CircleX size={size} className="text-danger" />,
+  approved: (size) => <CheckCircle size={size} className="text-success" />,
+});
+
+const ICON_SIZE = 56;
+
+export default function VerificationStatusBlock() {
+  const navigate = useNavigate();
+  const { user, submitVerificationRequest } = useAuth();
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [submittingKey, setSubmittingKey] = useState(null);
+  const [submitError, setSubmitError] = useState(null);
+  const [showSuccessToast, setShowSuccessToast] = useState(false);
+
+  const { modules: moduleStates = {}, summary = {} } = useVerificationModules(user);
+
+  const uploads = Array.isArray(user?.verificationUploads)
+    ? user.verificationUploads
+    : [];
+
+  const normalizeUploadCategory = (upload) => {
+    const raw =
+      upload?.verificationCategory ||
+      upload?.verificationKind ||
+      upload?.category ||
+      upload?.kind;
+    const value = typeof raw === 'string' ? raw.toLowerCase() : '';
+    if (value === 'address') return 'address';
+    return 'identity';
+  };
+
+  const hasIdentityUpload = uploads.some((upload) => normalizeUploadCategory(upload) === 'identity');
+
+  const normalizeString = (value) => (typeof value === 'string' ? value.trim() : '');
+  const hasEmailValue = normalizeString(user?.email).length >= 3;
+  const phoneDigits = user?.phone ? String(user.phone).replace(/\D/g, '') : '';
+  const hasPhoneValue = phoneDigits.length >= 10;
+  const genderValue = String(user?.gender || '').toLowerCase();
+  const hasDocStrings =
+    normalizeString(user?.firstName).length >= 2 &&
+    normalizeString(user?.lastName).length >= 2 &&
+    /^\d{4}-\d{2}-\d{2}$/.test(String(user?.dob || '')) &&
+    (genderValue === 'male' || genderValue === 'female');
+  const hasAddressStrings = ['country', 'city', 'address'].every((key) =>
+    normalizeString(user?.[key]).length >= 2,
+  );
+  const addressReady = hasAddressStrings && hasDocStrings;
+  const docReady = hasDocStrings && hasIdentityUpload;
+
+  const emailReady = hasEmailValue;
+  const phoneReady = hasPhoneValue;
+
+  const readinessMap = {
+    email: emailReady,
+    phone: phoneReady,
+    address: addressReady,
+    doc: docReady,
+  };
+
+  const items = VERIFICATION_MODULES.map((module) => ({
+    key: module.key,
+    label: module.label,
+    isReady: readinessMap[module.key],
+    state: moduleStates?.[module.key]?.status || 'idle',
+  }));
+
+  const hasAnyReady = items.some((item) => item.isReady);
+  const isRequestPending = Boolean(summary?.hasPending);
+  const isRequestRejected = Boolean(summary?.hasRejected);
+  const isRequestApproved = Boolean(summary?.allApproved);
+
+  const handleSubmit = async (originKey = null) => {
+    setSubmitError(null);
+    setShowSuccessToast(false);
+
+    if (!submitVerificationRequest) {
+      setSubmitError('Отправка доступна только авторизованным пользователям.');
+      return;
+    }
+
+    if (!hasAnyReady) {
+      setSubmitError('Заполните данные профиля перед отправкой на проверку.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    setSubmittingKey(originKey);
+
+    try {
+      const availableFields = Object.fromEntries(
+        Object.entries(readinessMap).filter(([key, isReady]) => {
+          if (!isReady) {
+            return false;
+          }
+
+          const state = moduleStates?.[key]?.status || 'idle';
+          return state === 'idle' || state === 'rejected';
+        }),
+      );
+
+      const requestedFieldKeys = (() => {
+        if (
+          originKey &&
+          Object.prototype.hasOwnProperty.call(availableFields, originKey)
+        ) {
+          return availableFields[originKey] ? { [originKey]: true } : {};
+        }
+
+        return { ...availableFields };
+      })();
+
+      if (!Object.keys(requestedFieldKeys).length) {
+        setSubmitError('Выберите пункт, который доступен для отправки на проверку.');
+        return;
+      }
+
+      await Promise.resolve(
+        submitVerificationRequest({
+          fields: requestedFieldKeys,
+          originKey,
+        }),
+      );
+      setShowSuccessToast(true);
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Не удалось отправить запрос. Попробуйте ещё раз.';
+      setSubmitError(message);
+    } finally {
+      setIsSubmitting(false);
+      setSubmittingKey(null);
+    }
+  };
+
+  const statusMessage = (() => {
+    if (isRequestPending) {
+      return 'Запрос отправлен и находится на проверке у администратора.';
+    }
+    if (isRequestRejected) {
+      return 'Некоторые пункты отклонены. Обновите данные и отправьте их повторно.';
+    }
+    if (isRequestApproved) {
+      return 'Все модули подтверждены. Изменения станут доступны после сброса статусов администратором.';
+    }
+    return hasAnyReady
+      ? 'После заполнения данных отправьте модуль на проверку под нужным пунктом.'
+      : 'Заполните хотя бы один пункт, чтобы отправить модуль на проверку.';
+  })();
+
+  return (
+    <>
+      <Card>
+        <Card.Body>
+          <Card.Title className="mb-3">Статусы верификации</Card.Title>
+          <Row className="text-center g-4">
+            {items.map((item) => {
+              const state = item.state;
+              const iconKey = ICON_COMPONENT[state] ? state : 'idle';
+              const iconLabel = `${item.label}: ${ICON_LABELS[iconKey] || ICON_LABELS.idle}`;
+              const iconComponent = ICON_COMPONENT[iconKey](ICON_SIZE);
+              const iconWrapper = (
+                <span
+                  className={`d-inline-flex align-items-center justify-content-center rounded-circle border border-2 shadow-sm ${ICON_BG_CLASS[iconKey] || ICON_BG_CLASS.idle}`}
+                  style={{ width: 92, height: 92 }}
+                >
+                  {iconComponent}
+                </span>
+              );
+
+              const canNavigateToPersonal =
+                !item.isReady && (iconKey === 'idle' || iconKey === 'rejected');
+              const canSubmit = item.isReady && (iconKey === 'idle' || iconKey === 'rejected');
+              const buttonVariant = iconKey === 'rejected' ? 'warning' : 'primary';
+              const buttonLabel =
+                isSubmitting && submittingKey === item.key ? 'Отправка…' : 'Подтвердить';
+              const showFillHint =
+                !item.isReady && (iconKey === 'idle' || iconKey === 'rejected');
+              const hintMessage = (() => {
+                switch (item.key) {
+                  case 'email':
+                    return hasEmailValue
+                      ? null
+                      : 'Добавьте почту в разделе «Персональные данные».';
+                  case 'phone':
+                    return hasPhoneValue
+                      ? null
+                      : 'Укажите номер телефона в разделе «Персональные данные».';
+                  case 'address':
+                    if (!hasAddressStrings) {
+                      return 'Заполните страну, город и адрес проживания.';
+                    }
+                    if (!hasDocStrings) {
+                      return 'Заполните ФИО, дату рождения и выберите пол.';
+                    }
+                    return null;
+                  case 'doc':
+                    if (!hasDocStrings) {
+                      return 'Заполните ФИО, дату рождения и выберите пол.';
+                    }
+                    if (!hasIdentityUpload) {
+                      return 'Загрузите документ, подтверждающий личность.';
+                    }
+                    return null;
+                  default:
+                    return null;
+                }
+              })();
+
+              return (
+                <Col key={item.key} xs={6} md={3} className="d-flex flex-column align-items-center">
+                  <div className="fw-medium mb-2">{item.label}</div>
+
+                  {canNavigateToPersonal ? (
+                    <Button
+                      variant="link"
+                      className="p-0 text-decoration-none"
+                      onClick={() => navigate('/profile/personal')}
+                      aria-label={`Открыть Персональные данные: ${item.label}`}
+                    >
+                      <span role="img" aria-label={iconLabel}>
+                        {iconWrapper}
+                      </span>
+                    </Button>
+                  ) : (
+                    <div role="img" aria-label={iconLabel}>
+                      {iconWrapper}
+                    </div>
+                  )}
+
+                {iconKey === 'pending' ? (
+                    <div className="mt-2 small fw-semibold text-warning">Ожидание</div>
+                  ) : null}
+
+              {canSubmit ? (
+                    <Button
+                      type="button"
+                      size="sm"
+                      variant={buttonVariant}
+                      className="mt-2 px-3"
+                      disabled={isSubmitting}
+                      onClick={() => {
+                        handleSubmit(item.key);
+                      }}
+                    >
+                      {buttonLabel}
+                    </Button>
+                  ) : null}
+
+                  {iconKey === 'approved'
+                    ? null
+                    : iconKey === 'pending'
+                      ? null
+                      : showFillHint
+                        ? (
+                            <div className="mt-2 small text-muted">
+                              {hintMessage || 'Заполните данные профиля'}
+                            </div>
+                          )
+                        : null}
+                </Col>
+              );
+            })}
+          </Row>
+
+          <div className="text-secondary small mt-4">{statusMessage}</div>
+
+          {submitError && (
+            <Alert variant="danger" className="mt-3 mb-0">
+              {submitError}
+            </Alert>
+          )}
+        </Card.Body>
+      </Card>
+      <ToastContainer position="bottom-end" className="p-3">
+        <Toast
+          bg="success"
+          onClose={() => setShowSuccessToast(false)}
+          show={showSuccessToast}
+          delay={4000}
+          autohide
+        >
+          <Toast.Body className="text-white">
+            Запрос отправлен в админ-панель на проверку.
+          </Toast.Body>
+        </Toast>
+      </ToastContainer>
+    </>
+  );
+}

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationStatusBlock/index.js
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationStatusBlock/index.js
@@ -1,0 +1,1 @@
+export { default } from './VerificationStatusBlock.jsx';

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationUploadBlock/VerificationUploadBlock.jsx
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationUploadBlock/VerificationUploadBlock.jsx
@@ -1,0 +1,179 @@
+import { Card, Form, Alert } from 'react-bootstrap';
+import { Upload } from 'lucide-react';
+import { useRef, useState, useMemo } from 'react';
+import { useAuth } from '../../../../../app/AuthContext.jsx';
+
+export default function VerificationUploadBlock() {
+  const ctx = useAuth?.() || {};
+  const addVerificationUpload = ctx.addVerificationUpload;
+  const fileRef = useRef(null);
+  const [category, setCategory] = useState('identity');
+  const [documentType, setDocumentType] = useState('');
+  const [error, setError] = useState('');
+  const [isUploading, setIsUploading] = useState(false);
+
+  const readFileAsDataUrl = (file) =>
+    new Promise((resolve, reject) => {
+      const reader = new FileReader();
+      reader.onload = () => resolve(reader.result);
+      reader.onerror = () => reject(new Error('Не удалось прочитать выбранный файл.'));
+      reader.readAsDataURL(file);
+    });
+
+  const categoryOptions = useMemo(
+    () => [
+      { value: 'address', label: 'Подтверждение адреса' },
+      { value: 'identity', label: 'Подтверждение личности' },
+    ],
+    [],
+  );
+
+  const addressDocumentOptions = useMemo(
+    () => [
+      { value: 'internet_statement', label: 'Интернет-выписка' },
+      { value: 'bank_statement', label: 'Банковская выписка' },
+    ],
+    [],
+  );
+
+  const identityDocumentOptions = useMemo(
+    () => [
+      { value: 'id_card', label: 'ID-карта' },
+      { value: 'foreign_passport', label: 'Заграничный паспорт' },
+      { value: 'internal_passport', label: 'Внутренний паспорт' },
+      { value: 'residence_permit', label: 'Вид на жительство' },
+    ],
+    [],
+  );
+
+  const documentOptions = category === 'address' ? addressDocumentOptions : identityDocumentOptions;
+  const selectedDocument = documentOptions.find((option) => option.value === documentType) || null;
+
+  const onPick = () => fileRef.current?.click();
+  const onCategoryChange = (event) => {
+    setCategory(event.target.value);
+    setDocumentType('');
+    setError('');
+  };
+
+  const onDocumentTypeChange = (event) => {
+    setDocumentType(event.target.value);
+    setError('');
+  };
+
+  const onChange = async (e) => {
+    const file = e.target.files?.[0];
+    if (!file) return;
+    if (!documentType) {
+      setError('Выберите вид документа перед загрузкой файла.');
+      e.target.value = '';
+      return;
+    }
+
+    setIsUploading(true);
+
+    try {
+      const dataUrl = await readFileAsDataUrl(file);
+      await Promise.resolve(
+        addVerificationUpload?.({
+          file: {
+            name: file.name,
+            type: file.type,
+            size: file.size,
+            lastModified: file.lastModified,
+            dataUrl,
+            previewUrl: dataUrl,
+          },
+          verificationKind: category,
+          verificationType: documentType,
+          verificationLabel: selectedDocument?.label,
+        }),
+      );
+      setError('');
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Не удалось загрузить документ.';
+      setError(message);
+    } finally {
+      setIsUploading(false);
+      e.target.value = '';
+    }
+  };
+
+  return (
+    <Card>
+      <Card.Body>
+        <Card.Title className="mb-3">Загрузка документов</Card.Title>
+
+        <div className="d-grid gap-3">
+          <Form.Group>
+            <Form.Label className="fw-medium">Что подтверждаем?</Form.Label>
+            <Form.Select value={category} onChange={onCategoryChange}>
+              {categoryOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Form.Select>
+          </Form.Group>
+
+          <Form.Group>
+            <Form.Label className="fw-medium">Вид документа</Form.Label>
+            <Form.Select
+              value={documentType}
+              onChange={onDocumentTypeChange}
+              aria-label="Выберите документ для подтверждения"
+            >
+              <option value="" disabled hidden>
+                Выберите из списка
+              </option>
+              {documentOptions.map((option) => (
+                <option key={option.value} value={option.value}>
+                  {option.label}
+                </option>
+              ))}
+            </Form.Select>
+            {category === 'address' ? (
+              <Form.Text className="text-secondary">
+                Подтвердить адрес можно интернет-выпиской или банковской выпиской с
+                заретушированными данными карт.
+              </Form.Text>
+            ) : (
+              <Form.Text className="text-secondary">
+                Подойдут ID-карта, заграничный или внутренний паспорт, вид на
+                жительство.
+              </Form.Text>
+            )}
+          </Form.Group>
+        </div>
+
+        <div
+          role="button"
+          onClick={onPick}
+          className="w-100 d-flex align-items-center justify-content-center rounded-3 p-5 text-center border border-2 border-secondary-subtle"
+          style={{ borderStyle: 'dashed' }}
+        >
+          <div>
+            <Upload className="mb-2" />
+            <div className="fw-medium">Нажмите, чтобы выбрать документ</div>
+            <div className="text-secondary small">Поддержка: PDF, JPG, PNG, WEBP</div>
+          </div>
+        </div>
+
+        {error && (
+          <Alert variant="danger" className="mt-3 mb-0">
+            {error}
+          </Alert>
+        )}
+
+        <Form.Control
+          ref={fileRef}
+          type="file"
+          accept=".pdf,.jpg,.jpeg,.png,.webp"
+          className="d-none"
+          onChange={onChange}
+          disabled={isUploading}
+        />
+      </Card.Body>
+    </Card>
+  );
+}

--- a/dodepus-casino/src/pages/profile/verification/blocks/VerificationUploadBlock/index.js
+++ b/dodepus-casino/src/pages/profile/verification/blocks/VerificationUploadBlock/index.js
@@ -1,0 +1,1 @@
+export { default } from './VerificationUploadBlock.jsx';

--- a/dodepus-casino/src/pages/profile/verification/blocks/index.js
+++ b/dodepus-casino/src/pages/profile/verification/blocks/index.js
@@ -1,0 +1,3 @@
+export { default as VerificationStatusBlock } from './VerificationStatusBlock';
+export { default as VerificationUploadBlock } from './VerificationUploadBlock';
+export { default as VerificationHistoryBlock } from './VerificationHistoryBlock';

--- a/dodepus-casino/src/pages/profile/verification/index.js
+++ b/dodepus-casino/src/pages/profile/verification/index.js
@@ -1,0 +1,1 @@
+export { default } from './Verification.jsx';

--- a/dodepus-casino/src/shared/verification/index.js
+++ b/dodepus-casino/src/shared/verification/index.js
@@ -1,0 +1,9 @@
+export {
+  VERIFICATION_MODULES,
+  VERIFICATION_STATUS_LABELS,
+  deriveModuleStatesFromRequests,
+  summarizeModuleStates,
+  buildVerificationTimeline,
+  formatModuleList,
+} from './modules.js';
+export { useVerificationModules } from './useVerificationModules.js';

--- a/dodepus-casino/src/shared/verification/modules.js
+++ b/dodepus-casino/src/shared/verification/modules.js
@@ -1,0 +1,421 @@
+const MODULE_KEYS = Object.freeze(['email', 'phone', 'address', 'doc']);
+
+export const VERIFICATION_MODULES = Object.freeze([
+  { key: 'email', label: 'Почта' },
+  { key: 'phone', label: 'Телефон' },
+  { key: 'address', label: 'Адрес' },
+  { key: 'doc', label: 'Документы' },
+]);
+
+export const VERIFICATION_STATUS_LABELS = Object.freeze({
+  idle: 'Нет запроса',
+  pending: 'На проверке',
+  approved: 'Подтверждено',
+  rejected: 'Отказано',
+});
+
+const normalizeStatus = (value) => {
+  if (typeof value !== 'string') {
+    return 'idle';
+  }
+
+  const normalized = value.trim().toLowerCase();
+  if (['pending', 'processing', 'in_review', 'review'].includes(normalized)) {
+    return 'pending';
+  }
+
+  if (['approved', 'verified', 'success'].includes(normalized)) {
+    return 'approved';
+  }
+
+  if (['rejected', 'declined', 'failed', 'error'].includes(normalized)) {
+    return 'rejected';
+  }
+
+  if (normalized === 'partial') {
+    return 'pending';
+  }
+
+  if (normalized === 'reset') {
+    return 'idle';
+  }
+
+  if (['waiting', 'idle', 'new', 'created', 'requested'].includes(normalized)) {
+    return 'idle';
+  }
+
+  return normalized || 'idle';
+};
+
+const normalizeBooleanMap = (input = {}) => {
+  if (!input || typeof input !== 'object') {
+    return MODULE_KEYS.reduce((acc, key) => {
+      acc[key] = false;
+      return acc;
+    }, {});
+  }
+
+  return MODULE_KEYS.reduce((acc, key) => {
+    acc[key] = Boolean(input[key]);
+    return acc;
+  }, {});
+};
+
+const parseTimestamp = (value) => {
+  if (!value) {
+    return 0;
+  }
+
+  try {
+    const parsed = Date.parse(value);
+    if (Number.isFinite(parsed)) {
+      return parsed;
+    }
+  } catch {
+    // ignore
+  }
+
+  return 0;
+};
+
+const createEmptyModuleState = () => ({
+  status: 'idle',
+  requested: false,
+  completed: false,
+  timestamp: 0,
+  updatedAt: null,
+  notes: '',
+  requestId: '',
+  source: '',
+});
+
+const ensureModuleMap = (input) => {
+  const next = {};
+  MODULE_KEYS.forEach((key) => {
+    next[key] = { ...createEmptyModuleState(), ...(input?.[key] || {}) };
+  });
+  return next;
+};
+
+const collectRecordsFromRequest = (request) => {
+  if (!request || typeof request !== 'object') {
+    return [];
+  }
+
+  const records = [];
+  const requestId = String(request.id || request.requestId || '') || '';
+  const baseStatus = normalizeStatus(request.status);
+  const baseTimestamp = parseTimestamp(
+    request.updatedAt || request.reviewedAt || request.submittedAt,
+  );
+  const baseNotes = typeof request.notes === 'string' ? request.notes : '';
+
+  const pushRecord = ({
+    key,
+    status,
+    requested,
+    completed,
+    timestamp,
+    updatedAt,
+    notes,
+    source,
+    cleared,
+  }) => {
+    if (!MODULE_KEYS.includes(key)) {
+      return;
+    }
+
+    const isCleared = Boolean(cleared);
+
+    if (!requested && !completed && !isCleared) {
+      return;
+    }
+
+    records.push({
+      key,
+      status: normalizeStatus(status),
+      requested: Boolean(requested || completed),
+      completed: Boolean(completed),
+      cleared: isCleared,
+      timestamp: Number.isFinite(timestamp) ? timestamp : 0,
+      updatedAt: updatedAt || null,
+      notes: typeof notes === 'string' ? notes : '',
+      requestId,
+      source,
+    });
+  };
+
+  const requestedFields = normalizeBooleanMap(
+    request.requestedFields ?? request.completedFields,
+  );
+  const completedFields = normalizeBooleanMap(request.completedFields);
+  const clearedFields = normalizeBooleanMap(request.clearedFields);
+
+  MODULE_KEYS.forEach((key) => {
+    pushRecord({
+      key,
+      status: baseStatus,
+      requested: requestedFields[key],
+      completed: completedFields[key],
+      cleared: clearedFields[key],
+      timestamp: baseTimestamp,
+      updatedAt:
+        request.updatedAt || request.reviewedAt || request.submittedAt || null,
+      notes: baseNotes,
+      source: 'request',
+    });
+  });
+
+  if (Array.isArray(request.history)) {
+    request.history.forEach((entry) => {
+      if (!entry || typeof entry !== 'object') {
+        return;
+      }
+
+      const entryStatus = normalizeStatus(entry.status || baseStatus);
+      const entryTimestamp = parseTimestamp(entry.updatedAt) || baseTimestamp;
+      const entryNotes = typeof entry.notes === 'string' ? entry.notes : baseNotes;
+      const entryRequested = normalizeBooleanMap(
+        entry.requestedFields ?? entry.completedFields,
+      );
+      const entryCompleted = normalizeBooleanMap(entry.completedFields);
+      const entryCleared = normalizeBooleanMap(entry.clearedFields);
+
+      MODULE_KEYS.forEach((key) => {
+        pushRecord({
+          key,
+          status: entryStatus,
+          requested: entryRequested[key],
+          completed: entryCompleted[key],
+          cleared: entryCleared[key],
+          timestamp: entryTimestamp,
+          updatedAt: entry.updatedAt || request.updatedAt || null,
+          notes: entryNotes,
+          source: 'history',
+        });
+      });
+    });
+  }
+
+  return records;
+};
+
+export const deriveModuleStatesFromRequests = (
+  requests,
+  { emailVerified = false } = {},
+) => {
+  const entries = Array.isArray(requests) ? requests : [];
+  const records = entries.flatMap((request) => collectRecordsFromRequest(request));
+
+  const map = ensureModuleMap();
+
+  records
+    .sort((a, b) => a.timestamp - b.timestamp)
+    .forEach((record) => {
+      const current = map[record.key] || createEmptyModuleState();
+      if (record.timestamp < current.timestamp) {
+        return;
+      }
+
+      let status = 'idle';
+      if (record.cleared) {
+        status = 'idle';
+      } else if (record.completed) {
+        status = 'approved';
+      } else if (record.status === 'rejected') {
+        status = 'rejected';
+      } else if (record.status === 'approved') {
+        status = record.requested ? 'approved' : 'idle';
+      } else if (record.status === 'partial' || record.status === 'pending') {
+        status = record.requested ? 'pending' : current.status;
+      } else {
+        status = record.requested ? 'pending' : 'idle';
+      }
+
+      map[record.key] = {
+        status,
+        requested: record.cleared ? false : record.requested,
+        completed: record.cleared ? false : record.completed,
+        timestamp: record.timestamp,
+        updatedAt: record.updatedAt,
+        notes: record.notes,
+        requestId: record.requestId,
+        source: record.source,
+      };
+    });
+
+  const next = ensureModuleMap(map);
+
+  if (emailVerified) {
+    const current = next.email || createEmptyModuleState();
+    if (current.status === 'idle') {
+      next.email = {
+        ...current,
+        status: 'approved',
+        requested: true,
+        completed: true,
+        source: current.source || 'profile',
+      };
+    }
+  }
+
+  return next;
+};
+
+export const summarizeModuleStates = (moduleMap) => {
+  const map = ensureModuleMap(moduleMap);
+
+  const summary = {
+    total: MODULE_KEYS.length,
+    approved: 0,
+    pending: 0,
+    rejected: 0,
+    idle: 0,
+    latestTimestamp: 0,
+  };
+
+  MODULE_KEYS.forEach((key) => {
+    const entry = map[key];
+    summary.latestTimestamp = Math.max(summary.latestTimestamp, entry.timestamp || 0);
+    switch (entry.status) {
+      case 'approved':
+        summary.approved += 1;
+        break;
+      case 'pending':
+        summary.pending += 1;
+        break;
+      case 'rejected':
+        summary.rejected += 1;
+        break;
+      default:
+        summary.idle += 1;
+        break;
+    }
+  });
+
+  summary.allApproved = summary.approved === summary.total;
+  summary.hasPending = summary.pending > 0;
+  summary.hasRejected = summary.rejected > 0;
+
+  if (summary.hasPending) {
+    summary.overall = 'pending';
+  } else if (summary.hasRejected) {
+    summary.overall = 'rejected';
+  } else if (summary.allApproved) {
+    summary.overall = 'approved';
+  } else {
+    summary.overall = 'idle';
+  }
+
+  return summary;
+};
+
+export const buildVerificationTimeline = (requests) => {
+  const entries = Array.isArray(requests) ? requests : [];
+  const events = [];
+
+  entries.forEach((request) => {
+    if (!request || typeof request !== 'object') {
+      return;
+    }
+
+    const requestId = String(request.id || request.requestId || '') || '';
+    const submittedAt = request.submittedAt || request.createdAt || null;
+    const submittedTimestamp = parseTimestamp(submittedAt);
+    const requestedFields = normalizeBooleanMap(
+      request.requestedFields ?? request.completedFields,
+    );
+
+    if (submittedTimestamp) {
+      events.push({
+        id: `${requestId}:submitted:${submittedTimestamp}`,
+        type: 'submitted',
+        status: 'pending',
+        modules: requestedFields,
+        updatedAt: submittedAt,
+        timestamp: submittedTimestamp,
+        notes: '',
+      });
+    }
+
+    if (Array.isArray(request.history) && request.history.length > 0) {
+      request.history.forEach((entry, index) => {
+        if (!entry || typeof entry !== 'object') {
+          return;
+        }
+
+        const entryTimestamp = parseTimestamp(entry.updatedAt);
+        const timestamp = entryTimestamp || parseTimestamp(request.updatedAt) || submittedTimestamp;
+        const modules = normalizeBooleanMap(
+          entry.status === 'reset'
+            ? entry.clearedFields
+            : entry.completedFields ?? entry.requestedFields ?? {},
+        );
+
+        events.push({
+          id: entry.id || `${requestId}:history:${index}`,
+          type: entry.status === 'reset' ? 'reset' : 'history',
+          status: normalizeStatus(entry.status || request.status),
+          modules,
+          updatedAt: entry.updatedAt || request.updatedAt || submittedAt,
+          timestamp,
+          notes: typeof entry.notes === 'string' ? entry.notes : '',
+        });
+      });
+    } else {
+      const status = normalizeStatus(request.status);
+      const timestamp =
+        parseTimestamp(request.reviewedAt) ||
+        parseTimestamp(request.updatedAt) ||
+        submittedTimestamp;
+
+      if (status && timestamp) {
+        events.push({
+          id: `${requestId}:final`,
+          type: status === 'reset' ? 'reset' : 'final',
+          status,
+          modules:
+            status === 'reset'
+              ? normalizeBooleanMap(request.clearedFields)
+              : normalizeBooleanMap(
+                  request.completedFields ?? request.requestedFields ?? {},
+                ),
+          updatedAt:
+            request.reviewedAt || request.updatedAt || request.submittedAt || null,
+          timestamp,
+          notes: typeof request.notes === 'string' ? request.notes : '',
+        });
+      }
+    }
+  });
+
+  const byId = new Map();
+  events.forEach((event) => {
+    if (!event || !event.id) {
+      return;
+    }
+
+    const existing = byId.get(event.id);
+    if (!existing || event.timestamp >= existing.timestamp) {
+      byId.set(event.id, event);
+    }
+  });
+
+  return Array.from(byId.values()).sort((a, b) => b.timestamp - a.timestamp);
+};
+
+export const formatModuleList = (modules) => {
+  const map = ensureModuleMap(
+    Array.isArray(modules)
+      ? modules.reduce((acc, key) => {
+          acc[key] = true;
+          return acc;
+        }, {})
+      : modules,
+  );
+
+  return VERIFICATION_MODULES.filter((module) => map[module.key])
+    .map((module) => module.label)
+    .join(', ');
+};
+

--- a/dodepus-casino/src/shared/verification/useVerificationModules.js
+++ b/dodepus-casino/src/shared/verification/useVerificationModules.js
@@ -1,0 +1,18 @@
+import { useMemo } from 'react';
+import {
+  deriveModuleStatesFromRequests,
+  summarizeModuleStates,
+} from './modules.js';
+
+export function useVerificationModules(user) {
+  const requests = Array.isArray(user?.verificationRequests)
+    ? user.verificationRequests
+    : [];
+  const emailVerified = Boolean(user?.emailVerified);
+
+  return useMemo(() => {
+    const modules = deriveModuleStatesFromRequests(requests, { emailVerified });
+    const summary = summarizeModuleStates(modules);
+    return { modules, summary };
+  }, [requests, emailVerified]);
+}


### PR DESCRIPTION
## Summary
- add shared verification helpers and surface verification progress in the profile layout
- implement the profile verification page with status controls, uploads, and history
- create the admin verification workspace with local-sim APIs, reset flows, and logging

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e5d3417124832fad747391b7195e12