### PR TITLE
feat: extend verification flows

### DIFF
--- a/dodepus-casino/docs/verification-flow.md
+++ b/dodepus-casino/docs/verification-flow.md
@@ -6,7 +6,7 @@
 
 | Шаг плана | Что требовалось | Реализация сейчас |
 | --- | --- | --- |
-| 1. Клиентская папка `profile/verification` | Подкаталоги `page`, `widgets`, `forms`, `state`, `actions`, `history`, `services`. | Структура выровнена: страница `page/VerificationPage.jsx`, статусы `widgets/ModuleStatusWidget.jsx`, формы `forms/DocumentUploadForm.jsx`, состояние `state/useVerificationState.js`, действия `actions/useVerificationActions.js`, история `history/VerificationHistory.jsx`, сервисы `services/verificationServices.js`. |
+| 1. Клиентская папка `profile/verification` | Подкаталоги `page`, `widgets`, `forms`, `state`, `actions`, `history`, `services`. | Структура выровнена: страница `page/VerificationPage.jsx`, статусы `widgets/ModuleStatusWidget.jsx`, формы `forms/EmailPhoneVerificationForm.jsx`, `forms/AddressVerificationForm.jsx`, `forms/DocumentsVerificationForm.jsx`, состояние `state/useVerificationState.js`, действия `actions/useVerificationActions.js`, история `history/VerificationHistory.jsx`, сервисы `services/verificationServices.js`. |
 | 2. Админка `admin/verification` | Аккордеоны, поиск, карточки, модалка, слой данных. | Страница `Verification.jsx` управляет поиском и группировкой, секции вынесены в `blocks`, модалка и бейджи в `components`, данные подгружает `hooks/useAdminVerificationRequests.js`. |
 | 3. `local-sim` | Таблицы, seed, логика, API. | Клиентские действия (`local-sim/auth/profileActions.js`) и админские (`local-sim/admin/verification.js`) поддерживают отправку, отмену, решения, сброс, историю и уведомления. |
 | 4. Навигация | Маршруты профиля и админки. | Маршруты `profile/personal`, `profile/verification`, `admin/verification` зарегистрированы и доступны через layout’ы. |
@@ -39,9 +39,13 @@
 
 ### 3.2 Страница и виджеты
 
-`page/VerificationPage.jsx` рендерит три блока: статусы, загрузку документов и историю. 【F:dodepus-casino/src/pages/profile/verification/page/VerificationPage.jsx†L1-L11】
+`page/VerificationPage.jsx` собирает статусы, две формы данных, блок загрузки документов и историю событий. 【F:dodepus-casino/src/pages/profile/verification/page/VerificationPage.jsx†L1-L24】
 
-### 3.3 Статусы и действия клиента
+### 3.3 Формы клиента
+
+`EmailPhoneVerificationForm` и `AddressVerificationForm` обновляют контакты и персональные данные напрямую из экрана верификации, повторяя блокировки модулей и добавляя подсказки. 【F:dodepus-casino/src/pages/profile/verification/forms/EmailPhoneVerificationForm.jsx†L1-L199】【F:dodepus-casino/src/pages/profile/verification/forms/AddressVerificationForm.jsx†L1-L259】
+
+### 3.4 Статусы и действия клиента
 
 `ModuleStatusWidget` показывает прогресс, подсказки, кнопки «Подтвердить» и «Отменить запрос». Кнопка отмены доступна для модулей в статусе ❓ и вызывает `cancelVerificationRequest`. После отмены выводится уведомление, статусы возвращаются в ◻️, поля разблокируются. 【F:dodepus-casino/src/pages/profile/verification/widgets/ModuleStatusWidget.jsx†L1-L260】
 
@@ -51,11 +55,11 @@
 - `address` — страна/город/адрес + ФИО/дата рождения/пол.
 - `doc` — выполнены требования адреса + загружен документ.
 
-### 3.4 Загрузка документов
+### 3.5 Загрузка документов
 
-`DocumentUploadForm` учитывает блокировки: если выбранная категория находится на проверке или подтверждена, формы и зона загрузки выключены и показывают подсказку. 【F:dodepus-casino/src/pages/profile/verification/forms/DocumentUploadForm.jsx†L1-L135】
+`DocumentsVerificationForm` учитывает блокировки: если выбранная категория находится на проверке или подтверждена, формы и зона загрузки выключены и показывают подсказку. 【F:dodepus-casino/src/pages/profile/verification/forms/DocumentUploadForm.jsx†L1-L202】
 
-### 3.5 История для клиента
+### 3.6 История для клиента
 
 `VerificationHistory` выводит таблицу событий и загрузок. Для отмен отображается статус «Запрос отменён клиентом», для административных действий — «Статусы сброшены администратором» и бейдж «Администратор». 【F:dodepus-casino/src/pages/profile/verification/history/VerificationHistory.jsx†L1-L103】
 
@@ -77,11 +81,15 @@
 
 ### 6.1 Отправка и отмена (клиент)
 
-`submitVerificationRequest` создаёт или дополняет открытую заявку. `cancelVerificationRequest` проверяет, что запрос ещё не обработан администратором, снимает выбранные модули, добавляет запись истории со статусом `cancelled` и возвращает заявку в `idle` (если всё снято) или `pending`. 【F:dodepus-casino/local-sim/auth/profileActions.js†L1-L266】【F:dodepus-casino/local-sim/auth/profileActions.js†L266-L392】
+`submitVerificationRequest` создаёт или дополняет открытую заявку. `cancelVerificationRequest` проверяет, что запрос ещё не обработан администратором, снимает выбранные модули, добавляет запись истории со статусом `cancelled` и возвращает заявку в `idle` (если всё снято) или `pending`. 【F:dodepus-casino/local-sim/auth/profileActions.js†L260-L456】
 
 ### 6.2 Действия администратора
 
-`updateVerificationRequestStatus` и `resetVerificationRequestModules` нормализуют статусы, обновляют историю, фиксируют администратора и уведомляют подписчиков `ADMIN_VERIFICATION_EVENT`. 【F:dodepus-casino/local-sim/admin/verification.js†L1-L360】【F:dodepus-casino/local-sim/admin/verification.js†L360-L640】
+`updateVerificationRequestStatus` и `resetVerificationRequestModules` нормализуют статусы, обновляют историю, фиксируют администратора и уведомляют подписчиков `ADMIN_VERIFICATION_EVENT`. 【F:dodepus-casino/local-sim/admin/verification.js†L432-L724】
+
+### 6.3 Общие таблицы и API
+
+Общий доступ к данным вынесен в `local-sim/tables/verification.js`, где описаны чтение и обновление снимка профиля. 【F:dodepus-casino/local-sim/tables/verification.js†L1-L52】 Логика нормализации статусов и полей собрана в `local-sim/logic/verificationHelpers.js`. 【F:dodepus-casino/local-sim/logic/verificationHelpers.js†L1-L100】 Предустановленные заявки для тестов описаны в `local-sim/seed/verificationSeed.js`. 【F:dodepus-casino/local-sim/seed/verificationSeed.js†L1-L102】 Клиентский и административный API собраны в `local-sim/api/verification.js`. 【F:dodepus-casino/local-sim/api/verification.js†L1-L8】
 
 ## 7. Поддерживаемые сценарии
 

--- a/dodepus-casino/local-sim/api/verification.js
+++ b/dodepus-casino/local-sim/api/verification.js
@@ -1,0 +1,10 @@
+export {
+  listAdminVerificationRequests,
+  subscribeToAdminVerificationRequests,
+  updateVerificationRequestStatus,
+  resetVerificationRequestModules,
+} from '../admin/verification.js';
+
+export {
+  createProfileActions as createClientVerificationActions,
+} from '../auth/profileActions.js';

--- a/dodepus-casino/local-sim/auth/accounts/seedLocalAuth.js
+++ b/dodepus-casino/local-sim/auth/accounts/seedLocalAuth.js
@@ -1,5 +1,6 @@
 import { PROFILE_KEY } from '../constants';
 import { pickExtras } from '../profileExtras';
+import { applyVerificationSeed } from '../../seed/verificationSeed.js';
 import { PRESET_ACCOUNTS } from './seedAccounts';
 
 const ADMIN_ROLES = new Set(['admin', 'owner']);
@@ -112,12 +113,14 @@ const toExtras = (account) => {
     account.email_confirmed_at ?? account.confirmed_at ?? account.extras?.emailVerified ?? false
   );
 
-  return pickExtras({
+  const extras = pickExtras({
     email: account.email,
     emailVerified,
     ...account.extras,
     user_metadata: undefined,
   });
+
+  return applyVerificationSeed(extras, account.id);
 };
 
 export const buildSeedUserRecords = () => PRESET_ACCOUNTS.map(toStoredUser);

--- a/dodepus-casino/local-sim/logic/verificationHelpers.js
+++ b/dodepus-casino/local-sim/logic/verificationHelpers.js
@@ -1,0 +1,100 @@
+const VALID_STATUSES = Object.freeze(['idle', 'pending', 'rejected', 'approved']);
+
+export const normalizeString = (value, fallback = '') => {
+  if (typeof value !== 'string') return fallback;
+  const trimmed = value.trim();
+  return trimmed || fallback;
+};
+
+export const normalizeStatus = (value) => {
+  const normalized = normalizeString(value).toLowerCase();
+  if (!normalized) return 'pending';
+  if (normalized === 'approved' || normalized === 'verified' || normalized === 'done') {
+    return 'approved';
+  }
+  if (normalized === 'rejected' || normalized === 'declined' || normalized === 'denied') {
+    return 'rejected';
+  }
+  if (['in_review', 'inreview', 'pending', 'processing'].includes(normalized)) {
+    return 'pending';
+  }
+  if (['waiting', 'idle', 'new', 'requested'].includes(normalized)) {
+    return 'idle';
+  }
+  if (normalized === 'partial') {
+    return 'pending';
+  }
+  if (normalized === 'reset') {
+    return 'idle';
+  }
+  if (VALID_STATUSES.includes(normalized)) {
+    return normalized;
+  }
+  return 'pending';
+};
+
+export const normalizeBooleanMap = (fields = {}) => {
+  const result = {};
+  if (!fields || typeof fields !== 'object') {
+    return { email: false, phone: false, address: false, doc: false };
+  }
+  ['email', 'phone', 'address', 'doc'].forEach((key) => {
+    result[key] = Boolean(fields[key]);
+  });
+  return result;
+};
+
+export const mergeFieldStates = (current = {}, patch = {}) => {
+  const normalizedCurrent = normalizeBooleanMap(current);
+  const normalizedPatch = normalizeBooleanMap(patch);
+  const keys = new Set([
+    ...Object.keys(normalizedCurrent),
+    ...Object.keys(normalizedPatch),
+  ]);
+
+  const result = {};
+  keys.forEach((key) => {
+    if (!key) return;
+    result[key] = normalizedPatch[key] ?? normalizedCurrent[key] ?? false;
+  });
+
+  return normalizeBooleanMap(result);
+};
+
+export const normalizeNotes = (value) => {
+  if (typeof value !== 'string') {
+    return '';
+  }
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : '';
+};
+
+export const normalizeFieldsPatch = (fields = {}) => {
+  if (!fields || typeof fields !== 'object') {
+    return {};
+  }
+
+  const patch = {};
+
+  if ('email' in fields) {
+    patch.email = Boolean(fields.email);
+  }
+
+  if ('phone' in fields) {
+    patch.phone = Boolean(fields.phone);
+  }
+
+  if ('address' in fields) {
+    patch.address = Boolean(fields.address);
+  }
+
+  if ('doc' in fields) {
+    patch.doc = Boolean(fields.doc);
+  }
+
+  if ('document' in fields) {
+    patch.doc = Boolean(fields.document);
+  }
+
+  return patch;
+};

--- a/dodepus-casino/local-sim/seed/verificationSeed.js
+++ b/dodepus-casino/local-sim/seed/verificationSeed.js
@@ -1,0 +1,133 @@
+import { normalizeBooleanMap } from '../logic/verificationHelpers.js';
+
+const clone = (value) => {
+  try {
+    return JSON.parse(JSON.stringify(value));
+  } catch {
+    return value;
+  }
+};
+
+const buildHistoryEntry = ({ requestId, status, reviewer, notes, completed, requested, cleared, updatedAt }) => ({
+  id: `seed-history-${Math.random().toString(36).slice(2, 8)}`,
+  requestId,
+  status,
+  reviewer,
+  notes,
+  updatedAt,
+  completedFields: normalizeBooleanMap(completed),
+  requestedFields: normalizeBooleanMap(requested ?? completed),
+  clearedFields: normalizeBooleanMap(cleared),
+});
+
+const baseRequest = ({ id, userId, status, submittedAt, updatedAt, completed, requested, history = [] }) => ({
+  id,
+  userId,
+  status,
+  submittedAt,
+  updatedAt,
+  completedFields: normalizeBooleanMap(completed),
+  requestedFields: normalizeBooleanMap(requested ?? completed),
+  completedCount: Object.values(normalizeBooleanMap(completed)).filter(Boolean).length,
+  totalFields: 4,
+  history: history.map(clone),
+});
+
+const SEED_REQUESTS = {
+  'seed-user-01': [
+    baseRequest({
+      id: 'seed-req-01',
+      userId: 'seed-user-01',
+      status: 'pending',
+      submittedAt: '2024-01-10T09:00:00.000Z',
+      updatedAt: '2024-01-10T09:00:00.000Z',
+      completed: { email: false, phone: false, address: false, doc: false },
+      requested: { email: true, phone: true, address: false, doc: false },
+    }),
+  ],
+  'seed-user-02': [
+    baseRequest({
+      id: 'seed-req-02',
+      userId: 'seed-user-02',
+      status: 'approved',
+      submittedAt: '2024-01-08T12:30:00.000Z',
+      updatedAt: '2024-01-09T15:45:00.000Z',
+      completed: { email: true, phone: true, address: false, doc: false },
+      requested: { email: true, phone: true, address: false, doc: false },
+      history: [
+        buildHistoryEntry({
+          requestId: 'seed-req-02',
+          status: 'approved',
+          updatedAt: '2024-01-09T15:45:00.000Z',
+          reviewer: { id: 'admin-seed', name: 'Seed Admin', role: 'admin' },
+          notes: 'Телефон подтверждён по смс-коду.',
+          completed: { email: true, phone: true, address: false, doc: false },
+        }),
+      ],
+    }),
+  ],
+  'seed-user-03': [
+    baseRequest({
+      id: 'seed-req-03',
+      userId: 'seed-user-03',
+      status: 'rejected',
+      submittedAt: '2024-01-05T08:10:00.000Z',
+      updatedAt: '2024-01-06T10:00:00.000Z',
+      completed: { email: true, phone: false, address: false, doc: false },
+      requested: { email: true, phone: true, address: false, doc: false },
+      history: [
+        buildHistoryEntry({
+          requestId: 'seed-req-03',
+          status: 'rejected',
+          updatedAt: '2024-01-06T10:00:00.000Z',
+          reviewer: { id: 'admin-seed', name: 'Seed Admin', role: 'admin' },
+          notes: 'Неверный формат номера. Укажите код страны.',
+          completed: { email: true, phone: false, address: false, doc: false },
+        }),
+      ],
+    }),
+  ],
+  'seed-user-04': [
+    baseRequest({
+      id: 'seed-req-04',
+      userId: 'seed-user-04',
+      status: 'approved',
+      submittedAt: '2024-01-02T11:20:00.000Z',
+      updatedAt: '2024-01-04T17:05:00.000Z',
+      completed: { email: true, phone: true, address: true, doc: true },
+      requested: { email: true, phone: true, address: true, doc: true },
+      history: [
+        buildHistoryEntry({
+          requestId: 'seed-req-04',
+          status: 'approved',
+          updatedAt: '2024-01-04T17:05:00.000Z',
+          reviewer: { id: 'admin-seed', name: 'Seed Admin', role: 'admin' },
+          notes: 'Полная верификация выполнена.',
+          completed: { email: true, phone: true, address: true, doc: true },
+        }),
+      ],
+    }),
+  ],
+};
+
+export const getVerificationSeedForUser = (userId) => {
+  const records = SEED_REQUESTS[userId];
+  if (!records) {
+    return { verificationRequests: [], verificationUploads: [] };
+  }
+  return { verificationRequests: clone(records), verificationUploads: [] };
+};
+
+export const applyVerificationSeed = (extras, userId) => {
+  const seed = getVerificationSeedForUser(userId);
+  if (!seed.verificationRequests.length) {
+    return extras;
+  }
+  return {
+    ...extras,
+    verificationRequests: seed.verificationRequests,
+    verificationUploads: Array.isArray(extras?.verificationUploads)
+      ? extras.verificationUploads
+      : [],
+  };
+};

--- a/dodepus-casino/local-sim/tables/verification.js
+++ b/dodepus-casino/local-sim/tables/verification.js
@@ -1,0 +1,53 @@
+import { loadExtras, saveExtras, pickExtras } from '../auth/profileExtras.js';
+
+const cloneArray = (value) => (Array.isArray(value) ? value.slice() : []);
+
+export const readVerificationSnapshot = (userId) => {
+  if (!userId) {
+    throw new Error('userId is required to read verification snapshot');
+  }
+
+  const extras = loadExtras(userId);
+  return {
+    extras,
+    requests: cloneArray(extras.verificationRequests),
+    uploads: cloneArray(extras.verificationUploads),
+  };
+};
+
+export const writeVerificationSnapshot = (userId, snapshot, baseSnapshot = null) => {
+  if (!userId) {
+    throw new Error('userId is required to write verification snapshot');
+  }
+
+  const reference = baseSnapshot ?? readVerificationSnapshot(userId);
+  const nextRequests = cloneArray(snapshot?.requests ?? reference.requests);
+  const nextUploads = cloneArray(snapshot?.uploads ?? reference.uploads);
+
+  const mergedExtras = {
+    ...reference.extras,
+    ...(snapshot?.extras ?? {}),
+    verificationRequests: nextRequests,
+    verificationUploads: nextUploads,
+  };
+
+  const normalized = pickExtras(mergedExtras);
+  saveExtras(userId, normalized);
+  return normalized;
+};
+
+export const updateVerificationSnapshot = (userId, updater) => {
+  if (typeof updater !== 'function') {
+    throw new Error('updater must be a function');
+  }
+
+  const base = readVerificationSnapshot(userId);
+  const draft = {
+    extras: { ...base.extras },
+    requests: cloneArray(base.requests),
+    uploads: cloneArray(base.uploads),
+  };
+
+  const result = updater(draft) || draft;
+  return writeVerificationSnapshot(userId, result, base);
+};

--- a/dodepus-casino/src/pages/Admin/verification/Verification.jsx
+++ b/dodepus-casino/src/pages/Admin/verification/Verification.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../../app/AuthContext.jsx';
 import {
   updateVerificationRequestStatus,
   resetVerificationRequestModules,
-} from '../../../../local-sim/admin/verification';
+} from '../../../../local-sim/api/verification.js';
 import { useAdminVerificationRequests } from './hooks/useAdminVerificationRequests.js';
 import VerificationRequestsBlock from './blocks/VerificationRequestsBlock.jsx';
 import VerificationPartialBlock from './blocks/VerificationPartialBlock.jsx';

--- a/dodepus-casino/src/pages/Admin/verification/hooks/useAdminVerificationRequests.js
+++ b/dodepus-casino/src/pages/Admin/verification/hooks/useAdminVerificationRequests.js
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   listAdminVerificationRequests,
   subscribeToAdminVerificationRequests,
-} from '../../../../../local-sim/admin/verification';
+} from '../../../../../local-sim/api/verification.js';
 
 const STORAGE_KEY_PREFIX = 'dodepus_profile_v1:';
 

--- a/dodepus-casino/src/pages/profile/verification/forms/AddressVerificationForm.jsx
+++ b/dodepus-casino/src/pages/profile/verification/forms/AddressVerificationForm.jsx
@@ -1,0 +1,259 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Card, Form, Row, Col, Button, Alert } from 'react-bootstrap';
+import { useAuth } from '../../../../app/AuthContext.jsx';
+import { useVerificationState } from '../state/useVerificationState.js';
+
+const GENDER_OPTIONS = [
+  { value: '', label: 'Выберите пол' },
+  { value: 'male', label: 'Мужчина' },
+  { value: 'female', label: 'Женщина' },
+];
+
+export function AddressVerificationForm() {
+  const { user, updateProfile } = useAuth();
+  const { locks } = useVerificationState();
+
+  const addressLocked = Boolean(locks.address);
+  const personalLocked = Boolean(locks.address || locks.doc);
+
+  const [firstName, setFirstName] = useState(user?.firstName ?? '');
+  const [lastName, setLastName] = useState(user?.lastName ?? '');
+  const [gender, setGender] = useState(
+    user?.gender === 'male' || user?.gender === 'female' ? user.gender : '',
+  );
+  const [dob, setDob] = useState(user?.dob ?? '');
+  const [country, setCountry] = useState(user?.country ?? '');
+  const [city, setCity] = useState(user?.city ?? '');
+  const [address, setAddress] = useState(user?.address ?? '');
+
+  const [status, setStatus] = useState({ type: null, message: '' });
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => setFirstName(user?.firstName ?? ''), [user?.firstName]);
+  useEffect(() => setLastName(user?.lastName ?? ''), [user?.lastName]);
+  useEffect(() => setGender(user?.gender === 'male' || user?.gender === 'female' ? user.gender : ''), [user?.gender]);
+  useEffect(() => setDob(user?.dob ?? ''), [user?.dob]);
+  useEffect(() => setCountry(user?.country ?? ''), [user?.country]);
+  useEffect(() => setCity(user?.city ?? ''), [user?.city]);
+  useEffect(() => setAddress(user?.address ?? ''), [user?.address]);
+
+  const trimmed = useMemo(
+    () => ({
+      firstName: (firstName || '').trim(),
+      lastName: (lastName || '').trim(),
+      country: (country || '').trim(),
+      city: (city || '').trim(),
+      address: (address || '').trim(),
+      gender,
+      dob: dob || null,
+    }),
+    [firstName, lastName, country, city, address, gender, dob],
+  );
+
+  const hasPersonalChanges = !personalLocked && (
+    trimmed.firstName !== (user?.firstName ?? '').trim() ||
+    trimmed.lastName !== (user?.lastName ?? '').trim() ||
+    trimmed.gender !== (user?.gender === 'male' || user?.gender === 'female' ? user.gender : '') ||
+    trimmed.dob !== (user?.dob ?? null)
+  );
+
+  const hasAddressChanges = !addressLocked && (
+    trimmed.country !== (user?.country ?? '').trim() ||
+    trimmed.city !== (user?.city ?? '').trim() ||
+    trimmed.address !== (user?.address ?? '').trim()
+  );
+
+  const hasChanges = hasPersonalChanges || hasAddressChanges;
+
+  const handleSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ type: null, message: '' });
+
+    if (!hasChanges) {
+      setStatus({ type: 'info', message: 'Изменений нет — данные актуальны.' });
+      return;
+    }
+
+    if (typeof updateProfile !== 'function') {
+      setStatus({ type: 'error', message: 'Сохранение данных временно недоступно.' });
+      return;
+    }
+
+    const patch = {};
+    if (hasPersonalChanges) {
+      patch.firstName = trimmed.firstName;
+      patch.lastName = trimmed.lastName;
+      patch.gender = trimmed.gender || '';
+      patch.dob = trimmed.dob;
+    }
+    if (hasAddressChanges) {
+      patch.country = trimmed.country;
+      patch.city = trimmed.city;
+      patch.address = trimmed.address;
+    }
+
+    setIsSaving(true);
+    try {
+      await Promise.resolve(updateProfile(patch));
+      setStatus({ type: 'success', message: 'Данные профиля сохранены.' });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Не удалось сохранить данные профиля. Попробуйте ещё раз.';
+      setStatus({ type: 'error', message });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const resetForm = () => {
+    setFirstName(user?.firstName ?? '');
+    setLastName(user?.lastName ?? '');
+    setGender(user?.gender === 'male' || user?.gender === 'female' ? user.gender : '');
+    setDob(user?.dob ?? '');
+    setCountry(user?.country ?? '');
+    setCity(user?.city ?? '');
+    setAddress(user?.address ?? '');
+    setStatus({ type: null, message: '' });
+  };
+
+  return (
+    <Card className="w-100">
+      <Card.Body>
+        <Card.Title className="mb-3">Персональные данные и адрес</Card.Title>
+        <Form onSubmit={handleSubmit} className="d-grid gap-3">
+          <Row className="g-3">
+            <Col md={6}>
+              <Form.Label>Имя</Form.Label>
+              <Form.Control
+                type="text"
+                value={firstName}
+                onChange={(event) => {
+                  if (personalLocked) return;
+                  setFirstName(event.target.value);
+                }}
+                placeholder="Иван"
+                disabled={personalLocked}
+              />
+            </Col>
+            <Col md={6}>
+              <Form.Label>Фамилия</Form.Label>
+              <Form.Control
+                type="text"
+                value={lastName}
+                onChange={(event) => {
+                  if (personalLocked) return;
+                  setLastName(event.target.value);
+                }}
+                placeholder="Иванов"
+                disabled={personalLocked}
+              />
+            </Col>
+          </Row>
+
+          <Row className="g-3">
+            <Col md={6}>
+              <Form.Label>Пол</Form.Label>
+              <Form.Select
+                value={gender}
+                onChange={(event) => {
+                  if (personalLocked) return;
+                  setGender(event.target.value);
+                }}
+                disabled={personalLocked}
+              >
+                {GENDER_OPTIONS.map((option) => (
+                  <option key={option.value} value={option.value}>
+                    {option.label}
+                  </option>
+                ))}
+              </Form.Select>
+            </Col>
+            <Col md={6}>
+              <Form.Label>Дата рождения</Form.Label>
+              <Form.Control
+                type="date"
+                value={dob ?? ''}
+                onChange={(event) => {
+                  if (personalLocked) return;
+                  setDob(event.target.value);
+                }}
+                disabled={personalLocked}
+                max={new Date(Date.now() - 568025136000).toISOString().slice(0, 10)}
+              />
+            </Col>
+          </Row>
+
+          <Row className="g-3">
+            <Col md={4}>
+              <Form.Label>Страна</Form.Label>
+              <Form.Control
+                type="text"
+                value={country}
+                onChange={(event) => {
+                  if (addressLocked) return;
+                  setCountry(event.target.value);
+                }}
+                placeholder="Украина"
+                disabled={addressLocked}
+              />
+            </Col>
+            <Col md={4}>
+              <Form.Label>Город</Form.Label>
+              <Form.Control
+                type="text"
+                value={city}
+                onChange={(event) => {
+                  if (addressLocked) return;
+                  setCity(event.target.value);
+                }}
+                placeholder="Киев"
+                disabled={addressLocked}
+              />
+            </Col>
+            <Col md={4}>
+              <Form.Label>Адрес проживания</Form.Label>
+              <Form.Control
+                type="text"
+                value={address}
+                onChange={(event) => {
+                  if (addressLocked) return;
+                  setAddress(event.target.value);
+                }}
+                placeholder="Улица, дом, квартира"
+                disabled={addressLocked}
+              />
+            </Col>
+          </Row>
+
+          <div className="text-secondary small">
+            {addressLocked || personalLocked
+              ? 'Поля блокируются во время проверки адреса или документов. Отмените запрос или дождитесь решения администратора.'
+              : 'Эти данные необходимы для проверки адреса и документов.'}
+          </div>
+
+          <div className="d-flex gap-2">
+            <Button type="submit" disabled={!hasChanges || isSaving}>
+              {isSaving ? 'Сохранение…' : 'Сохранить изменения'}
+            </Button>
+            <Button type="button" variant="outline-secondary" disabled={isSaving} onClick={resetForm}>
+              Сбросить
+            </Button>
+          </div>
+
+          {status.type ? (
+            <Alert
+              variant={status.type === 'error' ? 'danger' : status.type === 'success' ? 'success' : 'secondary'}
+              className="mb-0"
+            >
+              {status.message}
+            </Alert>
+          ) : null}
+        </Form>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default AddressVerificationForm;

--- a/dodepus-casino/src/pages/profile/verification/forms/DocumentUploadForm.jsx
+++ b/dodepus-casino/src/pages/profile/verification/forms/DocumentUploadForm.jsx
@@ -4,7 +4,7 @@ import { Upload, Lock } from 'lucide-react';
 import { useVerificationState } from '../state/useVerificationState.js';
 import { useVerificationActions } from '../actions/useVerificationActions.js';
 
-export function DocumentUploadForm() {
+export function DocumentsVerificationForm() {
   const fileRef = useRef(null);
   const { locks } = useVerificationState();
   const { addVerificationUpload } = useVerificationActions();
@@ -197,4 +197,6 @@ export function DocumentUploadForm() {
   );
 }
 
-export default DocumentUploadForm;
+export const DocumentUploadForm = DocumentsVerificationForm;
+
+export default DocumentsVerificationForm;

--- a/dodepus-casino/src/pages/profile/verification/forms/EmailPhoneVerificationForm.jsx
+++ b/dodepus-casino/src/pages/profile/verification/forms/EmailPhoneVerificationForm.jsx
@@ -1,0 +1,201 @@
+import { useEffect, useMemo, useState } from 'react';
+import { Card, Form, Row, Col, InputGroup, Dropdown, Button, Alert } from 'react-bootstrap';
+import { useAuth } from '../../../../app/AuthContext.jsx';
+import { useVerificationState } from '../state/useVerificationState.js';
+
+const DIAL_CODES = ['+380', '+7', '+375', '+370', '+371', '+372', '+48', '+995', '+374'];
+
+const splitPhone = (full = '') => {
+  if (typeof full !== 'string' || !full.trim()) {
+    return { dial: '+380', number: '' };
+  }
+
+  const normalized = full.trim();
+  if (!normalized.startsWith('+')) {
+    return { dial: '+380', number: normalized.replace(/\D/g, '') };
+  }
+
+  const dial = DIAL_CODES.find((code) => normalized.startsWith(code));
+  if (dial) {
+    return { dial, number: normalized.slice(dial.length).replace(/\D/g, '') };
+  }
+
+  return { dial: '+380', number: normalized.replace(/\D/g, '') };
+};
+
+const composePhone = (dial, number) => {
+  const digits = String(number ?? '').replace(/\D/g, '');
+  if (!digits) return '';
+  const prefix = DIAL_CODES.includes(dial) ? dial : '+380';
+  return `${prefix}${digits}`;
+};
+
+export function EmailPhoneVerificationForm() {
+  const { user, updateContacts } = useAuth();
+  const { locks } = useVerificationState();
+
+  const emailLocked = Boolean(locks.email);
+  const phoneLocked = Boolean(locks.phone);
+
+  const [email, setEmail] = useState(user?.email ?? '');
+  const initialPhone = useMemo(() => splitPhone(user?.phone), [user?.phone]);
+  const [dial, setDial] = useState(initialPhone.dial);
+  const [number, setNumber] = useState(initialPhone.number);
+
+  const [status, setStatus] = useState({ type: null, message: '' });
+  const [isSaving, setIsSaving] = useState(false);
+
+  useEffect(() => {
+    setEmail(user?.email ?? '');
+  }, [user?.email]);
+
+  useEffect(() => {
+    const next = splitPhone(user?.phone);
+    setDial(next.dial);
+    setNumber(next.number);
+  }, [user?.phone]);
+
+  const currentPhone = useMemo(() => composePhone(dial, number), [dial, number]);
+
+  const hasEmailChange = !emailLocked && email !== (user?.email ?? '');
+  const hasPhoneChange = !phoneLocked && currentPhone !== (user?.phone ?? '');
+  const hasChanges = hasEmailChange || hasPhoneChange;
+
+  const onSubmit = async (event) => {
+    event.preventDefault();
+    setStatus({ type: null, message: '' });
+
+    if (!hasChanges) {
+      setStatus({ type: 'info', message: 'Изменений нет — данные уже актуальны.' });
+      return;
+    }
+
+    if (typeof updateContacts !== 'function') {
+      setStatus({ type: 'error', message: 'Обновление контактов временно недоступно.' });
+      return;
+    }
+
+    const payload = {};
+    if (hasEmailChange) {
+      payload.email = email.trim();
+    }
+    if (hasPhoneChange) {
+      payload.phone = currentPhone;
+    }
+
+    setIsSaving(true);
+    try {
+      await Promise.resolve(updateContacts(payload));
+      setStatus({ type: 'success', message: 'Контактные данные сохранены.' });
+    } catch (error) {
+      const message =
+        error instanceof Error
+          ? error.message
+          : 'Не удалось сохранить контакты. Попробуйте ещё раз.';
+      setStatus({ type: 'error', message });
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  const infoMessage = (() => {
+    if (phoneLocked || emailLocked) {
+      return 'Поля блокируются, пока соответствующий модуль на проверке или подтверждён.';
+    }
+    return 'E-mail и телефон используются для входа и подтверждения личности.';
+  })();
+
+  return (
+    <Card className="w-100">
+      <Card.Body>
+        <Card.Title className="mb-3">Почта и номер телефона</Card.Title>
+        <Form onSubmit={onSubmit} className="d-grid gap-3">
+          <Row className="g-3">
+            <Col md={6}>
+              <Form.Label>Электронная почта</Form.Label>
+              <Form.Control
+                type="email"
+                value={email}
+                onChange={(event) => {
+                  if (emailLocked) return;
+                  setEmail(event.target.value);
+                }}
+                placeholder="you@example.com"
+                autoComplete="email"
+                disabled={emailLocked}
+              />
+            </Col>
+            <Col md={6}>
+              <Form.Label>Номер телефона</Form.Label>
+              <InputGroup>
+                <Dropdown onSelect={(value) => !phoneLocked && setDial(value || dial)}>
+                  <Dropdown.Toggle
+                    id="verification-phone-dial"
+                    variant="outline-secondary"
+                    className="flex-shrink-0"
+                    style={{ width: 96 }}
+                    disabled={phoneLocked}
+                  >
+                    {dial}
+                  </Dropdown.Toggle>
+                  <Dropdown.Menu align="start" style={{ minWidth: 96 }}>
+                    {DIAL_CODES.map((code) => (
+                      <Dropdown.Item key={code} eventKey={code} active={code === dial}>
+                        {code}
+                      </Dropdown.Item>
+                    ))}
+                  </Dropdown.Menu>
+                </Dropdown>
+                <Form.Control
+                  type="tel"
+                  value={number}
+                  placeholder="Номер"
+                  inputMode="numeric"
+                  maxLength={12}
+                  onChange={(event) => {
+                    if (phoneLocked) return;
+                    setNumber(event.target.value.replace(/\D/g, ''));
+                  }}
+                  autoComplete="tel"
+                  disabled={phoneLocked}
+                />
+              </InputGroup>
+            </Col>
+          </Row>
+
+          <div className="text-secondary small">{infoMessage}</div>
+
+          <div className="d-flex gap-2">
+            <Button type="submit" disabled={!hasChanges || isSaving}>
+              {isSaving ? 'Сохранение…' : 'Сохранить изменения'}
+            </Button>
+            <Button
+              type="button"
+              variant="outline-secondary"
+              disabled={isSaving || (!hasEmailChange && !hasPhoneChange)}
+              onClick={() => {
+                setEmail(user?.email ?? '');
+                setDial(initialPhone.dial);
+                setNumber(initialPhone.number);
+                setStatus({ type: null, message: '' });
+              }}
+            >
+              Сбросить
+            </Button>
+          </div>
+
+          {status.type ? (
+            <Alert
+              variant={status.type === 'error' ? 'danger' : status.type === 'success' ? 'success' : 'secondary'}
+              className="mb-0"
+            >
+              {status.message}
+            </Alert>
+          ) : null}
+        </Form>
+      </Card.Body>
+    </Card>
+  );
+}
+
+export default EmailPhoneVerificationForm;

--- a/dodepus-casino/src/pages/profile/verification/forms/index.js
+++ b/dodepus-casino/src/pages/profile/verification/forms/index.js
@@ -1,1 +1,3 @@
-export { DocumentUploadForm } from './DocumentUploadForm.jsx';
+export { EmailPhoneVerificationForm } from './EmailPhoneVerificationForm.jsx';
+export { AddressVerificationForm } from './AddressVerificationForm.jsx';
+export { DocumentsVerificationForm, DocumentUploadForm } from './DocumentUploadForm.jsx';

--- a/dodepus-casino/src/pages/profile/verification/page/VerificationPage.jsx
+++ b/dodepus-casino/src/pages/profile/verification/page/VerificationPage.jsx
@@ -1,12 +1,25 @@
+import { Row, Col } from 'react-bootstrap';
 import { ModuleStatusWidget } from '../widgets/ModuleStatusWidget.jsx';
-import { DocumentUploadForm } from '../forms/DocumentUploadForm.jsx';
+import {
+  EmailPhoneVerificationForm,
+  AddressVerificationForm,
+  DocumentsVerificationForm,
+} from '../forms/index.js';
 import { VerificationHistory } from '../history/VerificationHistory.jsx';
 
 export default function VerificationPage() {
   return (
     <div className="d-grid gap-4">
       <ModuleStatusWidget />
-      <DocumentUploadForm />
+      <Row className="g-4">
+        <Col lg={6} className="d-flex">
+          <EmailPhoneVerificationForm />
+        </Col>
+        <Col lg={6} className="d-flex">
+          <AddressVerificationForm />
+        </Col>
+      </Row>
+      <DocumentsVerificationForm />
       <VerificationHistory />
     </div>
   );


### PR DESCRIPTION
## Summary
- add dedicated email/phone and address forms to the verification screen alongside the document upload block
- refresh documentation to cover the new client forms and reorganized local simulator responsibilities
- extract shared verification helpers, tables, seed data, and API re-exports for the local simulator used by both client and admin

## Testing
- npm run lint *(fails: existing repository lint issues unrelated to these changes)*

------
https://chatgpt.com/codex/tasks/task_e_68e5f8cf2248832f90fcb4797fc5b735