### PR TITLE
Fix local auth role config imports

### DIFF
--- a/dodepus-casino/local-sim/auth/admin/adminPanelVisibility.js
+++ b/dodepus-casino/local-sim/auth/admin/adminPanelVisibility.js
@@ -1,4 +1,4 @@
-import { availableRoles } from '../../../src/pages/admin/access/roles/data/roleConfigs.js';
+import { availableRoles } from '../../../src/pages/admin/features/access/roles/data/roleConfigs.js';
 
 const STORAGE_KEY = 'dodepus_admin_panel_visibility_v1';
 export const ADMIN_PANEL_VISIBILITY_EVENT = 'dodepus:admin-panel-visibility-change';

--- a/dodepus-casino/local-sim/auth/api.js
+++ b/dodepus-casino/local-sim/auth/api.js
@@ -7,7 +7,7 @@ import {
 } from './accounts/seedLocalAuth';
 import { composeUser } from './composeUser';
 import { loadExtras, saveExtras } from './profileExtras';
-import { availableRoles } from '../../src/pages/admin/access/roles/data/roleConfigs.js';
+import { availableRoles } from '../../src/pages/admin/features/access/roles/data/roleConfigs.js';
 
 const USERS_KEY = 'dodepus_local_users_v1';
 const SESSION_KEY = 'dodepus_local_session_v1';

--- a/dodepus-casino/local-sim/auth/composeUser.js
+++ b/dodepus-casino/local-sim/auth/composeUser.js
@@ -1,5 +1,5 @@
 import { pickExtras } from './profileExtras';
-import { availableRoles } from '../../src/pages/admin/access/roles/data/roleConfigs.js';
+import { availableRoles } from '../../src/pages/admin/features/access/roles/data/roleConfigs.js';
 
 export const isAdminUser = (user) =>
   Boolean(


### PR DESCRIPTION
## Summary
- update the local auth API helper to load admin role configs from the features path
- align the admin visibility helper with the new admin role config location

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68e636d89404832f846bb0f376ae9968