### PR TITLE
Fix relative imports for admin modules

### DIFF
--- a/dodepus-casino/local-sim/admin/features/verification/index.js
+++ b/dodepus-casino/local-sim/admin/features/verification/index.js
@@ -1,5 +1,5 @@
 import { readAdminClients } from '../clients/index.js';
-import { appendAdminLog } from './logs.js';
+import { appendAdminLog } from '../../logs/index.js';
 import {
   normalizeString,
   normalizeStatus,

--- a/dodepus-casino/local-sim/admin/logs/index.js
+++ b/dodepus-casino/local-sim/admin/logs/index.js
@@ -1,19 +1,19 @@
-import { ADMINISTRATORS_CHAT_LOGS } from '../modules/communications/administratorsChatLogs.js';
-import { CLIENTS_LOGS } from '../modules/clients/logs.js';
-import { MODERATORS_CHAT_LOGS } from '../modules/communications/moderatorsChatLogs.js';
-import { PROMOCODE_CREATE_LOGS } from '../modules/promo/createLogs.js';
-import { PROMOCODES_LOGS } from '../modules/promo/listLogs.js';
-import { PROMO_ARCHIVE_LOGS } from '../modules/promo/archiveLogs.js';
-import { ROLE_EDIT_LOGS } from '../modules/access/roleEditLogs.js';
-import { ROLES_LOGS } from '../modules/access/rolesLogs.js';
-import { STAFF_CHAT_LOGS } from '../modules/communications/staffChatLogs.js';
-import { VERIFICATION_LOGS } from '../modules/verification/logs.js';
+import { ADMINISTRATORS_CHAT_LOGS } from '../features/communications/administratorsChatLogs.js';
+import { CLIENTS_LOGS } from '../features/clients/logs.js';
+import { MODERATORS_CHAT_LOGS } from '../features/communications/moderatorsChatLogs.js';
+import { PROMOCODE_CREATE_LOGS } from '../features/promo/createLogs.js';
+import { PROMOCODES_LOGS } from '../features/promo/listLogs.js';
+import { PROMO_ARCHIVE_LOGS } from '../features/promo/archiveLogs.js';
+import { ROLE_EDIT_LOGS } from '../features/access/roleEditLogs.js';
+import { ROLES_LOGS } from '../features/access/rolesLogs.js';
+import { STAFF_CHAT_LOGS } from '../features/communications/staffChatLogs.js';
+import { VERIFICATION_LOGS } from '../features/verification/logs.js';
 import {
   TRANSACTIONS_LOG_STORAGE_KEY,
   TRANSACTIONS_STATIC_LOGS,
   appendTransactionLog,
   readTransactionLogs,
-} from '../modules/transactions/logs.js';
+} from '../features/transactions/logs.js';
 
 const ADMIN_LOG_SECTIONS = Object.freeze([
   { value: 'overview', label: 'Обзор' },

--- a/dodepus-casino/local-sim/api/verification.js
+++ b/dodepus-casino/local-sim/api/verification.js
@@ -3,7 +3,7 @@ export {
   subscribeToAdminVerificationRequests,
   updateVerificationRequestStatus,
   resetVerificationRequestModules,
-} from '../admin/verification.js';
+} from '../admin/features/verification/index.js';
 
 export {
   createProfileActions as createClientVerificationActions,

--- a/dodepus-casino/local-sim/auth/profileActions.js
+++ b/dodepus-casino/local-sim/auth/profileActions.js
@@ -1,5 +1,5 @@
 import { loadExtras, saveExtras, pickExtras } from './profileExtras';
-import { notifyAdminTransactionsChanged } from '../admin/transactions';
+import { notifyAdminTransactionsChanged } from '../admin/features/transactions/index.js';
 import { updateVerificationSnapshot } from '../tables/verification.js';
 import { normalizeNotes, normalizeBooleanMap } from '../logic/verificationHelpers.js';
 

--- a/dodepus-casino/src/pages/admin/features/access/roles/blocks/EditRole/EditRolePermissions.jsx
+++ b/dodepus-casino/src/pages/admin/features/access/roles/blocks/EditRole/EditRolePermissions.jsx
@@ -14,7 +14,7 @@ import {
   ADMIN_PANEL_VISIBILITY_EVENT,
   loadAdminPanelVisibility,
   setAdminPanelVisibilityForRole,
-} from '../../../../../../local-sim/auth/admin/adminPanelVisibility';
+} from '../../../../../../../../local-sim/auth/admin/adminPanelVisibility.js';
 import { appendRolePermissionLog } from '../../../../../../../../local-sim/admin/features/access/rolePermissionLogs.js';
 
 const permissionKeys = Object.keys(roleMatrixLegend);

--- a/dodepus-casino/src/pages/admin/features/access/roles/blocks/RolesMatrix.jsx
+++ b/dodepus-casino/src/pages/admin/features/access/roles/blocks/RolesMatrix.jsx
@@ -7,7 +7,7 @@ import {
 import {
   ADMIN_PANEL_VISIBILITY_EVENT,
   loadAdminPanelVisibility,
-} from '../../../../../local-sim/auth/admin/adminPanelVisibility';
+} from '../../../../../../../local-sim/auth/admin/adminPanelVisibility.js';
 
 export default function RolesMatrix() {
   const permissionKeys = Object.keys(roleMatrixLegend);

--- a/dodepus-casino/src/pages/admin/features/clients/blocks/ClientSearchFilters.jsx
+++ b/dodepus-casino/src/pages/admin/features/clients/blocks/ClientSearchFilters.jsx
@@ -1,6 +1,6 @@
 import { useMemo } from 'react';
 import { Form, Row, Col } from 'react-bootstrap';
-import { getRoleOptions, getStatusOptions } from '../../../../../local-sim/admin/shared/filters.js';
+import { getRoleOptions, getStatusOptions } from '../../../../../../local-sim/admin/shared/filters.js';
 
 const balanceOptions = [
   { value: 'all', label: 'Все балансы' },

--- a/dodepus-casino/src/pages/admin/features/clients/blocks/ClientStats.jsx
+++ b/dodepus-casino/src/pages/admin/features/clients/blocks/ClientStats.jsx
@@ -1,5 +1,5 @@
 import { Placeholder, Row, Col } from 'react-bootstrap';
-import { useTheme } from '../../../../app/ThemeContext.jsx';
+import { useTheme } from '../../../../../app/ThemeContext.jsx';
 
 function formatCurrency(value) {
   return new Intl.NumberFormat('ru-RU', {

--- a/dodepus-casino/src/pages/admin/features/communications/administrators-chat/AdministratorsChat.jsx
+++ b/dodepus-casino/src/pages/admin/features/communications/administrators-chat/AdministratorsChat.jsx
@@ -1,5 +1,5 @@
-import ChatPanel from '../../shared/ChatPanel.jsx';
-import { administratorsChatThreads } from '../roles/data/roleConfigs.js';
+import ChatPanel from '../../../shared/ChatPanel.jsx';
+import { administratorsChatThreads } from '../../access/roles/data/roleConfigs.js';
 
 export default function AdministratorsChat() {
   const activeThread = administratorsChatThreads[0];

--- a/dodepus-casino/src/pages/admin/features/communications/moderators-chat/ModeratorsChat.jsx
+++ b/dodepus-casino/src/pages/admin/features/communications/moderators-chat/ModeratorsChat.jsx
@@ -1,5 +1,5 @@
-import ChatPanel from '../../shared/ChatPanel.jsx';
-import { moderatorsChatThreads } from '../roles/data/roleConfigs.js';
+import ChatPanel from '../../../shared/ChatPanel.jsx';
+import { moderatorsChatThreads } from '../../access/roles/data/roleConfigs.js';
 
 export default function ModeratorsChat() {
   const activeThread = moderatorsChatThreads[0];

--- a/dodepus-casino/src/pages/admin/features/communications/staff-chat/StaffChat.jsx
+++ b/dodepus-casino/src/pages/admin/features/communications/staff-chat/StaffChat.jsx
@@ -1,5 +1,5 @@
-import ChatPanel from '../../shared/ChatPanel.jsx';
-import { staffChatThreads } from '../roles/data/roleConfigs.js';
+import ChatPanel from '../../../shared/ChatPanel.jsx';
+import { staffChatThreads } from '../../access/roles/data/roleConfigs.js';
 
 export default function StaffChat() {
   const activeThread = staffChatThreads[0];

--- a/dodepus-casino/src/pages/admin/features/monitoring/log-admin/LogAdmin.jsx
+++ b/dodepus-casino/src/pages/admin/features/monitoring/log-admin/LogAdmin.jsx
@@ -18,7 +18,7 @@ import {
   getAdminLogSectionLabel,
   getAdminLogSections,
   listAdminLogs,
-} from '../../../../local-sim/admin/logs/index.js';
+} from '../../../../../../local-sim/admin/logs/index.js';
 
 const formatDateTime = (value) => {
   if (!value) return '';

--- a/dodepus-casino/src/pages/admin/features/transactions/blocks/TransactionsHistory.jsx
+++ b/dodepus-casino/src/pages/admin/features/transactions/blocks/TransactionsHistory.jsx
@@ -8,7 +8,7 @@ import { METHOD_LABELS, STATUS_VARIANTS, TYPE_VARIANTS } from '../constants.js';
 import { formatMethod, normalizeMethodValue } from '../utils.js';
 import { useAdminTransactions } from '../hooks/useAdminTransactions.js';
 import { useAuth } from '../../../../../app/AuthContext.jsx';
-import { appendAdminLog } from '../../../../../local-sim/admin/logs/index.js';
+import { appendAdminLog } from '../../../../../../local-sim/admin/logs/index.js';
 
 const TRANSACTIONS_VIEW_CONTEXT = 'transactions-view';
 

--- a/dodepus-casino/src/pages/admin/features/verification/Verification.jsx
+++ b/dodepus-casino/src/pages/admin/features/verification/Verification.jsx
@@ -5,7 +5,7 @@ import { useAuth } from '../../../../app/AuthContext.jsx';
 import {
   updateVerificationRequestStatus,
   resetVerificationRequestModules,
-} from '../../../../local-sim/api/verification.js';
+} from '../../../../../local-sim/api/verification.js';
 import { useAdminVerificationRequests } from './hooks/useAdminVerificationRequests.js';
 import VerificationRequestsBlock from './blocks/VerificationRequestsBlock.jsx';
 import VerificationPartialBlock from './blocks/VerificationPartialBlock.jsx';

--- a/dodepus-casino/src/pages/admin/features/verification/hooks/useAdminVerificationRequests.js
+++ b/dodepus-casino/src/pages/admin/features/verification/hooks/useAdminVerificationRequests.js
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 import {
   listAdminVerificationRequests,
   subscribeToAdminVerificationRequests,
-} from '../../../../../local-sim/api/verification.js';
+} from '../../../../../../local-sim/api/verification.js';
 
 const STORAGE_KEY_PREFIX = 'dodepus_profile_v1:';
 

--- a/dodepus-casino/src/pages/admin/layout/AdminLayout.jsx
+++ b/dodepus-casino/src/pages/admin/layout/AdminLayout.jsx
@@ -3,7 +3,7 @@ import { Container, Row, Col, Nav, Card } from 'react-bootstrap';
 import { NavLink, Outlet } from 'react-router-dom';
 
 import { useAuth } from '../../../app/AuthContext.jsx';
-import { availableRoles, rolePermissionMatrix } from '../access/roles/data/roleConfigs.js';
+import { availableRoles, rolePermissionMatrix } from '../features/access/roles/data/roleConfigs.js';
 
 const NAV_ITEMS = [
   { key: 'overview', to: 'overview', label: 'Обзор', permission: 'overview' },

--- a/dodepus-casino/src/pages/catalog/providers/details/page/ProviderDetailsPage.jsx
+++ b/dodepus-casino/src/pages/catalog/providers/details/page/ProviderDetailsPage.jsx
@@ -1,7 +1,7 @@
 import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Row, Col, Card, Badge, Button, Alert } from 'react-bootstrap';
-import { games } from '../../../../../../data/games.js';
+import { games } from '../../../../../data/games.js';
 
 function GameThumb() {
   return (

--- a/dodepus-casino/src/pages/catalog/providers/list/page/ProvidersListPage.jsx
+++ b/dodepus-casino/src/pages/catalog/providers/list/page/ProvidersListPage.jsx
@@ -1,8 +1,8 @@
 import { useMemo } from 'react';
 import { useParams, Link } from 'react-router-dom';
 import { Row, Col, Card, Badge, Button, Alert } from 'react-bootstrap';
-import { games } from '../../../../../../data/games.js';
-import GameCover from '../../../../../../shared/ui/GameCover.jsx';
+import { games } from '../../../../../data/games.js';
+import GameCover from '../../../../../shared/ui/GameCover.jsx';
 
 export default function ProviderPage() {
   const { provider } = useParams(); // slug провайдера


### PR DESCRIPTION
## Summary
- fix broken relative imports throughout the admin simulator modules to match the current directory structure
- update admin communication and catalog pages to pull shared data/components from the correct locations
- adjust verification and log features to reference the consolidated admin log utilities

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68e639414768832f9c2d8c009aa539b1